### PR TITLE
Adjust clustrmaps widget size and add lab page redirect

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,9 @@
 {% if site.footer_fixed %}
 <footer class="fixed-bottom">
   <div class="container mt-0">
+    <div style="text-align: center; margin-bottom: 15px; transform: scale(0.7); transform-origin: center;">
+      <script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI"></script>
+    </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
     {{ site.footer_text }}
     {% if site.impressum_path %}
@@ -9,12 +12,14 @@
     {% if site.last_updated %}
     Last updated: {{ "now" | date: '%B %d, %Y' }}.
     {% endif %}
-    <script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI"></script>
   </div>
 </footer>
 {% else %}
 <footer class="sticky-bottom mt-5">
   <div class="container">
+    <div style="text-align: center; margin-bottom: 15px; transform: scale(0.7); transform-origin: center;">
+      <script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI"></script>
+    </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
     {{ site.footer_text }}
     {% if site.impressum_path %}
@@ -23,7 +28,6 @@
     {% if site.last_updated %}
     Last updated: {{ "now" | date: '%B %d, %Y' }}.
     {% endif %}
-    <script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI"></script>
   </div>
 </footer>
 {% endif %}

--- a/_pages/lab.md
+++ b/_pages/lab.md
@@ -7,6 +7,11 @@ nav: true
 importance: 6
 ---
 
+<meta http-equiv="refresh" content="0; url=https://vilab-group.com/">
+<script type="text/javascript">
+    window.location.href = "https://vilab-group.com/";
+</script>
+
 <style>
   .lab-container {
     max-width: 1000px;


### PR DESCRIPTION
- Scale down clustrmaps widget to 70% of original size
- Reposition clustrmaps above copyright text in footer
- Add automatic redirect from /lab/ to https://vilab-group.com/

🤖 Generated with [Claude Code](https://claude.com/claude-code)