### PR TITLE
Reduce clustrmaps widget size from 70% to 50%

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 {% if site.footer_fixed %}
 <footer class="fixed-bottom">
   <div class="container mt-0">
-    <div style="text-align: center; margin-bottom: 15px; transform: scale(0.7); transform-origin: center;">
+    <div style="text-align: center; margin-bottom: 15px; transform: scale(0.5); transform-origin: center;">
       <script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI"></script>
     </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
@@ -17,7 +17,7 @@
 {% else %}
 <footer class="sticky-bottom mt-5">
   <div class="container">
-    <div style="text-align: center; margin-bottom: 15px; transform: scale(0.7); transform-origin: center;">
+    <div style="text-align: center; margin-bottom: 15px; transform: scale(0.5); transform-origin: center;">
       <script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI"></script>
     </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.


### PR DESCRIPTION
Scaled down the widget further to make it less prominent in the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)