### PR TITLE
Update clustrmaps to use map_v2.js version

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
 <footer class="fixed-bottom">
   <div class="container mt-0">
     <div style="text-align: center; margin-top: 5px; margin-bottom: 5px; transform: scale(0.375); transform-origin: center;">
-      <script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI"></script>
+      <script type='text/javascript' id='clustrmaps' src='//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=h7ooXORXRrMSgdMmJAjMrdMUjhK-HWDDmtNXLnK06Tw'></script>
     </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
     {{ site.footer_text }}
@@ -18,7 +18,7 @@
 <footer class="sticky-bottom mt-5">
   <div class="container">
     <div style="text-align: center; margin-top: 5px; margin-bottom: 5px; transform: scale(0.375); transform-origin: center;">
-      <script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI"></script>
+      <script type='text/javascript' id='clustrmaps' src='//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=h7ooXORXRrMSgdMmJAjMrdMUjhK-HWDDmtNXLnK06Tw'></script>
     </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
     {{ site.footer_text }}


### PR DESCRIPTION
Replaced the globe.js clustrmaps widget with the map_v2.js version as requested, maintaining the existing scaling and positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)