### PR TITLE
Restore teaser image display functionality

### DIFF
--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -4,12 +4,7 @@
 <div class="row">
   <div class="col-sm-3 abbr">
   {% if entry.teaser %}
-    {% assign teaser_name = entry.teaser | split: '.' | first %}
-    {% assign teaser_ext = entry.teaser | split: '.' | last %}
-    <picture>
-      <source type="image/webp" srcset="../assets/teaser/{{ teaser_name }}.webp">
-      <img src="../assets/teaser/{{entry.teaser}}" class="teaser img-fluid z-depth-1" loading="lazy" alt="{{ entry.title }}">
-    </picture>
+    <img src="../assets/teaser/{{entry.teaser}}" class="teaser img-fluid z-depth-1">
   {% endif %}
   {% if entry.abbr %}
         {% if site.data.venues[entry.abbr] %}


### PR DESCRIPTION
The recent WebP optimization was preventing teaser images from showing. Reverted to the simple img tag format that works reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)