### PR TITLE
update

### DIFF
--- a/_pages/research-biometrics.md
+++ b/_pages/research-biometrics.md
@@ -1,0 +1,89 @@
+---
+layout: page
+permalink: /research/biometrics-digital-identity/
+title: Trustworthy Biometrics and Digital Identity
+description:
+nav: false
+importance: 92
+---
+
+<div class="research-container">
+
+  <div class="research-hero">
+    <div class="research-eyebrow">Research Direction</div>
+    <h1>Trustworthy Biometrics and Digital Identity</h1>
+    <p>How do we create, recognize, and protect human identity in a world increasingly
+    populated by synthetic people, avatars, and AI-generated media?</p>
+  </div>
+
+  <div class="research-section">
+    <p>Our longest and most cited line of work spans face, body, and gait recognition;
+    open-set and large-scale identification; long-range and aerial recognition; deepfake
+    detection; and synthetic identity. As digital entities and AI-generated media
+    proliferate, we study how to recognize real people robustly, generate identity-aware
+    synthetic data, detect manipulation, and provision secure identity &mdash; with
+    fairness, privacy, and explainability built in.</p>
+  </div>
+
+  <div class="research-section">
+    <h2>What we work on</h2>
+    <ul class="research-bullets">
+      <li>Face, body, gait, and multimodal biometrics</li>
+      <li>Open-set and large-scale recognition</li>
+      <li>Long-range and aerial person recognition</li>
+      <li>Robustness across clothing, pose, viewpoint, and time</li>
+      <li>Synthetic biometric data</li>
+      <li>Deepfake detection and media authenticity</li>
+      <li>Privacy-preserving recognition</li>
+      <li>Digital and virtual identity</li>
+      <li>Fairness, explainability, and uncertainty</li>
+      <li>Secure identity for AI-generated digital entities</li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Selected work</h2>
+    <ul class="research-works">
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/1910.01717" target="_blank">On the Detection of Digital Face Manipulation</a></span><br>
+        <span class="work-venue">CVPR 2020</span>
+      </li>
+      <li>
+        <span class="work-title">DCFace: Synthetic Face Generation with Dual Condition Diffusion Model</span><br>
+        <span class="work-venue">CVPR 2023</span>
+      </li>
+      <li>
+        <span class="work-title">Open-Set Biometrics: Beyond Good Closed-Set Models</span><br>
+        <span class="work-venue">ECCV 2024</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2605.18238" target="_blank">Non-Colliding Biometric Identities for Digital Entities: Geometry, Capacity, and Million-Scale Virtual Identity Provisioning</a></span><br>
+        <span class="work-venue">2026</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2606.26384" target="_blank">What Do Deepfake Benchmarks Measure? An Audit Using Frozen Self-Supervised Representations</a></span><br>
+        <span class="work-venue">2026</span>
+      </li>
+      <li>
+        <span class="work-title">Controllable and Guided Face Synthesis for Unconstrained Face Recognition</span><br>
+        <span class="work-venue">ECCV 2022</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Where it applies</h2>
+    <div class="research-tags">
+      <span class="research-tag">Identity verification</span>
+      <span class="research-tag">Fraud prevention</span>
+      <span class="research-tag">Content authenticity &amp; provenance</span>
+      <span class="research-tag">Public safety &amp; defense</span>
+      <span class="research-tag">Synthetic-data generation</span>
+      <span class="research-tag">Privacy-preserving analytics</span>
+      <span class="research-tag">Avatar &amp; virtual-world identity</span>
+    </div>
+  </div>
+
+  <a class="research-back" href="{{ '/research/' | relative_url }}">&larr; All research</a>
+
+</div>

--- a/_pages/research-biometrics.md
+++ b/_pages/research-biometrics.md
@@ -49,11 +49,11 @@ importance: 92
         <span class="work-venue">CVPR 2020</span>
       </li>
       <li>
-        <span class="work-title">DCFace: Synthetic Face Generation with Dual Condition Diffusion Model</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2304.07060" target="_blank">DCFace: Synthetic Face Generation with Dual Condition Diffusion Model</a></span><br>
         <span class="work-venue">CVPR 2023</span>
       </li>
       <li>
-        <span class="work-title">Open-Set Biometrics: Beyond Good Closed-Set Models</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2407.16133" target="_blank">Open-Set Biometrics: Beyond Good Closed-Set Models</a></span><br>
         <span class="work-venue">ECCV 2024</span>
       </li>
       <li>
@@ -65,7 +65,7 @@ importance: 92
         <span class="work-venue">2026</span>
       </li>
       <li>
-        <span class="work-title">Controllable and Guided Face Synthesis for Unconstrained Face Recognition</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2207.10180" target="_blank">Controllable and Guided Face Synthesis for Unconstrained Face Recognition</a></span><br>
         <span class="work-venue">ECCV 2022</span>
       </li>
     </ul>

--- a/_pages/research-education.md
+++ b/_pages/research-education.md
@@ -43,11 +43,11 @@ importance: 95
     <h2>Selected work</h2>
     <ul class="research-works">
       <li>
-        <span class="work-title">Can Multimodal LLMs See Science Instruction? Benchmarking Pedagogical Reasoning in K-12 Classroom Videos</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2602.18466" target="_blank">Can Multimodal LLMs See Science Instruction? Benchmarking Pedagogical Reasoning in K-12 Classroom Videos</a></span><br>
         <span class="work-venue">AIED 2026</span>
       </li>
       <li>
-        <span class="work-title">DrawSim-PD: Simulating Student Science Drawings to Support NGSS-Aligned Teacher Diagnostic Reasoning</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2602.01578" target="_blank">DrawSim-PD: Simulating Student Science Drawings to Support NGSS-Aligned Teacher Diagnostic Reasoning</a></span><br>
         <span class="work-venue">AIED 2026</span>
       </li>
       <li>

--- a/_pages/research-education.md
+++ b/_pages/research-education.md
@@ -1,0 +1,73 @@
+---
+layout: page
+permalink: /research/ai-education-scientific-learning/
+title: AI for Education and Scientific Learning
+description:
+nav: false
+importance: 95
+---
+
+<div class="research-container">
+
+  <div class="research-hero">
+    <div class="research-eyebrow">Impact Area</div>
+    <h1>AI for Education and Scientific Learning</h1>
+    <p>We develop multimodal AI systems that reason about student thinking, instructional
+    practice, and the evidence educators use to make decisions.</p>
+  </div>
+
+  <div class="research-section">
+    <p>Our education research is not general-purpose tutoring or chatbots. It focuses on
+    the multimodal evidence of learning &mdash; classroom video, student scientific
+    drawings, and teacher decision-making &mdash; and on AI that does not merely recognize
+    classroom activity but reasons about student understanding, instructional quality, and
+    the evidence behind educational decisions.</p>
+  </div>
+
+  <div class="research-section">
+    <h2>What we work on</h2>
+    <ul class="research-bullets">
+      <li>Multimodal understanding of classroom instruction</li>
+      <li>AI-supported teacher feedback and decision-making</li>
+      <li>Student drawing and scientific model assessment</li>
+      <li>Diagnostic reasoning about student understanding</li>
+      <li>Generative simulation of student work</li>
+      <li>Video-based analysis of teaching and learning</li>
+      <li>Evaluation of multimodal foundation models in education</li>
+      <li>Human&ndash;AI collaboration for educators</li>
+      <li>Personalized and evidence-grounded learning support</li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Selected work</h2>
+    <ul class="research-works">
+      <li>
+        <span class="work-title">Can Multimodal LLMs See Science Instruction? Benchmarking Pedagogical Reasoning in K-12 Classroom Videos</span><br>
+        <span class="work-venue">AIED 2026</span>
+      </li>
+      <li>
+        <span class="work-title">DrawSim-PD: Simulating Student Science Drawings to Support NGSS-Aligned Teacher Diagnostic Reasoning</span><br>
+        <span class="work-venue">AIED 2026</span>
+      </li>
+      <li>
+        <span class="work-title">Automatically Assess Elementary Students' Hand-Drawn Scientific Models Using Deep Learning</span><br>
+        <span class="work-venue">ICLS 2023</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Where it applies</h2>
+    <div class="research-tags">
+      <span class="research-tag">K-12 science education</span>
+      <span class="research-tag">Teacher professional development</span>
+      <span class="research-tag">Formative assessment</span>
+      <span class="research-tag">EdTech</span>
+      <span class="research-tag">Learning analytics</span>
+    </div>
+  </div>
+
+  <a class="research-back" href="{{ '/research/' | relative_url }}">&larr; All research</a>
+
+</div>

--- a/_pages/research-generative.md
+++ b/_pages/research-generative.md
@@ -43,19 +43,19 @@ importance: 93
     <h2>Selected work</h2>
     <ul class="research-works">
       <li>
-        <span class="work-title">TIGER: Time-Varying Denoising Model for 3D Point Cloud Generation with Diffusion Process</span><br>
+        <span class="work-title"><a href="https://cvlab.cse.msu.edu/pdfs/Ren_Kim_Liu_Liu_TIGER.pdf" target="_blank">TIGER: Time-Varying Denoising Model for 3D Point Cloud Generation with Diffusion Process</a></span><br>
         <span class="work-venue">CVPR 2024</span>
       </li>
       <li>
-        <span class="work-title">2D GANs Meet Unsupervised Single-View 3D Reconstruction</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2207.10183" target="_blank">2D GANs Meet Unsupervised Single-View 3D Reconstruction</a></span><br>
         <span class="work-venue">ECCV 2022</span>
       </li>
       <li>
-        <span class="work-title">Learning Implicit Functions for Topology-Varying Dense 3D Shape Correspondence</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2212.14276" target="_blank">Learning Implicit Functions for Topology-Varying Dense 3D Shape Correspondence</a></span><br>
         <span class="work-venue">NeurIPS 2020 (Oral) / TPAMI 2023</span>
       </li>
       <li>
-        <span class="work-title">Bridge: Basis-Driven Causal Inference Marries VFMs for Domain Generalization</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2604.26820" target="_blank">Bridge: Basis-Driven Causal Inference Marries VFMs for Domain Generalization</a></span><br>
         <span class="work-venue">CVPR 2026</span>
       </li>
       <li>

--- a/_pages/research-generative.md
+++ b/_pages/research-generative.md
@@ -1,0 +1,88 @@
+---
+layout: page
+permalink: /research/generative-multimodal-ai/
+title: Generative and Multimodal AI for the Physical World
+description:
+nav: false
+importance: 93
+---
+
+<div class="research-container">
+
+  <div class="research-hero">
+    <div class="research-eyebrow">Research Direction</div>
+    <h1>Generative and Multimodal AI for the Physical World</h1>
+    <p>Can generative and multimodal models produce and reason about the physical world
+    with geometric and physical consistency &mdash; enough to drive perception,
+    simulation, and robotics?</p>
+  </div>
+
+  <div class="research-section">
+    <p>We develop generative and multimodal models that respect the structure of the
+    physical world: 3D-aware and geometry-consistent generation, controllable synthesis,
+    and vision-language reasoning that generalizes across domains. These models produce
+    synthetic data for perception systems, power simulation for autonomous systems and
+    robotics, and increasingly run efficiently at the edge.</p>
+  </div>
+
+  <div class="research-section">
+    <h2>What we work on</h2>
+    <ul class="research-bullets">
+      <li>3D-aware and geometry-consistent generative models</li>
+      <li>Controllable human and scene generation</li>
+      <li>Synthetic data for perception systems</li>
+      <li>Vision-language models and multimodal reasoning</li>
+      <li>Domain generalization and causal representation learning</li>
+      <li>Physical consistency in generative AI</li>
+      <li>Simulation for autonomous systems and robotics</li>
+      <li>Efficient and edge-deployable generative AI</li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Selected work</h2>
+    <ul class="research-works">
+      <li>
+        <span class="work-title">TIGER: Time-Varying Denoising Model for 3D Point Cloud Generation with Diffusion Process</span><br>
+        <span class="work-venue">CVPR 2024</span>
+      </li>
+      <li>
+        <span class="work-title">2D GANs Meet Unsupervised Single-View 3D Reconstruction</span><br>
+        <span class="work-venue">ECCV 2022</span>
+      </li>
+      <li>
+        <span class="work-title">Learning Implicit Functions for Topology-Varying Dense 3D Shape Correspondence</span><br>
+        <span class="work-venue">NeurIPS 2020 (Oral) / TPAMI 2023</span>
+      </li>
+      <li>
+        <span class="work-title">Bridge: Basis-Driven Causal Inference Marries VFMs for Domain Generalization</span><br>
+        <span class="work-venue">CVPR 2026</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2602.20195" target="_blank">OrgFlow: Generative Modeling of Organic Crystal Structures from Molecular Graphs</a></span><br>
+        <span class="work-venue">2026</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2509.21576" target="_blank">Vision Language Models Cannot Plan, but Can They Formalize?</a></span><br>
+        <span class="work-venue">2025</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Where it applies</h2>
+    <div class="research-tags">
+      <span class="research-tag">Autonomous driving</span>
+      <span class="research-tag">Robotics</span>
+      <span class="research-tag">Simulation &amp; synthetic data</span>
+      <span class="research-tag">Digital twins</span>
+      <span class="research-tag">Content creation</span>
+      <span class="research-tag">AR / VR</span>
+      <span class="research-tag">Edge AI</span>
+      <span class="research-tag">Scientific &amp; engineering design</span>
+    </div>
+  </div>
+
+  <a class="research-back" href="{{ '/research/' | relative_url }}">&larr; All research</a>
+
+</div>

--- a/_pages/research-health.md
+++ b/_pages/research-health.md
@@ -1,0 +1,78 @@
+---
+layout: page
+permalink: /research/ai-health-human-performance/
+title: AI for Health and Human Performance
+description:
+nav: false
+importance: 94
+---
+
+<div class="research-container">
+
+  <div class="research-hero">
+    <div class="research-eyebrow">Impact Area</div>
+    <h1>AI for Health and Human Performance</h1>
+    <p>Current clinical assessments often rely on short observations, subjective scores, or
+    specialized equipment. We develop interpretable, video-based biomarkers that quantify
+    how an individual moves, changes over time, and responds to intervention.</p>
+  </div>
+
+  <div class="research-section">
+    <p>This impact area applies our human-modeling and biomechanics research to health,
+    mobility, and human performance. We build interpretable systems &mdash; grounded in
+    biomechanics and explained in language clinicians and patients can act on &mdash; for
+    remote, unobtrusive, and longitudinal assessment.</p>
+    <div class="research-note">
+      <strong>How this differs from Physical Human Intelligence:</strong> Physical Human
+      Intelligence asks <em>how</em> machines can understand human bodies and movement.
+      AI for Health and Human Performance <em>applies</em> those capabilities to mobility,
+      rehabilitation, disease monitoring, coaching, and personalized assessment.
+    </div>
+  </div>
+
+  <div class="research-section">
+    <h2>What we work on</h2>
+    <ul class="research-bullets">
+      <li>Video-based digital biomarkers</li>
+      <li>Clinical gait and mobility assessment</li>
+      <li>Longitudinal tracking of disease and recovery</li>
+      <li>Personalized movement analysis</li>
+      <li>Rehabilitation monitoring</li>
+      <li>Biomechanics-grounded clinical AI</li>
+      <li>Physical coaching and skill assessment</li>
+      <li>Human performance and readiness</li>
+      <li>Remote and unobtrusive health assessment</li>
+      <li>Interpretable vision-language systems for clinicians and patients</li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Selected work</h2>
+    <ul class="research-works">
+      <li>
+        <span class="work-title">BioGait-VLM: A Tri-Modal Vision-Language-Biomechanics Framework for Interpretable Clinical Gait Assessment</span><br>
+        <span class="work-venue">MICCAI 2026</span>
+      </li>
+      <li>
+        <span class="work-title">From 3D Pose to Prose: Biomechanics-Grounded Vision&ndash;Language Coaching</span><br>
+        <span class="work-venue">CVPR 2026</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Where it applies</h2>
+    <div class="research-tags">
+      <span class="research-tag">Hospitals &amp; clinics</span>
+      <span class="research-tag">Rehabilitation</span>
+      <span class="research-tag">Medical devices</span>
+      <span class="research-tag">Clinical trials</span>
+      <span class="research-tag">Sports medicine</span>
+      <span class="research-tag">Remote patient monitoring</span>
+      <span class="research-tag">Defense medical &amp; readiness</span>
+    </div>
+  </div>
+
+  <a class="research-back" href="{{ '/research/' | relative_url }}">&larr; All research</a>
+
+</div>

--- a/_pages/research-health.md
+++ b/_pages/research-health.md
@@ -50,11 +50,11 @@ importance: 94
     <h2>Selected work</h2>
     <ul class="research-works">
       <li>
-        <span class="work-title">BioGait-VLM: A Tri-Modal Vision-Language-Biomechanics Framework for Interpretable Clinical Gait Assessment</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2603.08564" target="_blank">BioGait-VLM: A Tri-Modal Vision-Language-Biomechanics Framework for Interpretable Clinical Gait Assessment</a></span><br>
         <span class="work-venue">MICCAI 2026</span>
       </li>
       <li>
-        <span class="work-title">From 3D Pose to Prose: Biomechanics-Grounded Vision&ndash;Language Coaching</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2603.26938" target="_blank">From 3D Pose to Prose: Biomechanics-Grounded Vision&ndash;Language Coaching</a></span><br>
         <span class="work-venue">CVPR 2026</span>
       </li>
     </ul>

--- a/_pages/research-human.md
+++ b/_pages/research-human.md
@@ -42,27 +42,27 @@ importance: 90
     <h2>Selected work</h2>
     <ul class="research-works">
       <li>
-        <span class="work-title">Distilling CLIP with Dual Guidance for Learning Discriminative Human Body Shape Representation</span><br>
+        <span class="work-title"><a href="https://cvlab.cse.msu.edu/pdfs/Liu_Kim_Ren_Liu_CLIP3DREID.pdf" target="_blank">Distilling CLIP with Dual Guidance for Learning Discriminative Human Body Shape Representation</a></span><br>
         <span class="work-venue">CVPR 2024</span>
       </li>
       <li>
-        <span class="work-title">SapiensID: Foundation for Human Recognition</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2504.04708" target="_blank">SapiensID: Foundation for Human Recognition</a></span><br>
         <span class="work-venue">CVPR 2025</span>
       </li>
       <li>
-        <span class="work-title">From 3D Pose to Prose: Biomechanics-Grounded Vision&ndash;Language Coaching</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2603.26938" target="_blank">From 3D Pose to Prose: Biomechanics-Grounded Vision&ndash;Language Coaching</a></span><br>
         <span class="work-venue">CVPR 2026</span>
       </li>
       <li>
-        <span class="work-title">Learning Clothing and Pose Invariant 3D Shape Representation for Long-Term Person Re-Identification</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2308.10658" target="_blank">Learning Clothing and Pose Invariant 3D Shape Representation for Long-Term Person Re-Identification</a></span><br>
         <span class="work-venue">ICCV 2023</span>
       </li>
       <li>
-        <span class="work-title">Farsight: A Physics-Driven Whole-Body Biometric System at Large Distance and Altitude</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2306.17206" target="_blank">FarSight: A Physics-Driven Whole-Body Biometric System at Large Distance and Altitude</a></span><br>
         <span class="work-venue">WACV 2024</span>
       </li>
       <li>
-        <span class="work-title">ROG-Grasp: Root-Oriented Geometry for Robotic Grasping and Placement</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2606.00449" target="_blank">ROG-Grasp: Root-Oriented Geometry for Robotic Grasping and Placement</a></span><br>
         <span class="work-venue">IEEE CASE 2026</span>
       </li>
     </ul>

--- a/_pages/research-human.md
+++ b/_pages/research-human.md
@@ -1,0 +1,86 @@
+---
+layout: page
+permalink: /research/physical-human-intelligence/
+title: Physical Human Intelligence
+description:
+nav: false
+importance: 90
+---
+
+<div class="research-container">
+
+  <div class="research-hero">
+    <div class="research-eyebrow">Research Direction</div>
+    <h1>Physical Human Intelligence</h1>
+    <p>How can machines understand the human body &mdash; its shape, motion, and
+    biomechanics &mdash; well enough to model, simulate, and reason about what a person
+    is doing and how well they do it?</p>
+  </div>
+
+  <div class="research-section">
+    <p>We build models that recover and reason about the human body from images and video:
+    its 3D geometry, pose, motion, appearance, and biomechanical state. The goal is not
+    pose estimation alone, but a complete physical understanding of people &mdash; their
+    movement, skill, and interaction with the world &mdash; that can drive digital humans,
+    health, and embodied AI.</p>
+  </div>
+
+  <div class="research-section">
+    <h2>What we work on</h2>
+    <ul class="research-bullets">
+      <li>3D human reconstruction and digitization</li>
+      <li>Human shape, pose, motion, and appearance modeling</li>
+      <li>Biomechanics-grounded human understanding</li>
+      <li>Human&ndash;object interaction</li>
+      <li>Physical skill and task proficiency assessment</li>
+      <li>Digital humans and human simulation</li>
+      <li>Human understanding for robotics and embodied AI</li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Selected work</h2>
+    <ul class="research-works">
+      <li>
+        <span class="work-title">Distilling CLIP with Dual Guidance for Learning Discriminative Human Body Shape Representation</span><br>
+        <span class="work-venue">CVPR 2024</span>
+      </li>
+      <li>
+        <span class="work-title">SapiensID: Foundation for Human Recognition</span><br>
+        <span class="work-venue">CVPR 2025</span>
+      </li>
+      <li>
+        <span class="work-title">From 3D Pose to Prose: Biomechanics-Grounded Vision&ndash;Language Coaching</span><br>
+        <span class="work-venue">CVPR 2026</span>
+      </li>
+      <li>
+        <span class="work-title">Learning Clothing and Pose Invariant 3D Shape Representation for Long-Term Person Re-Identification</span><br>
+        <span class="work-venue">ICCV 2023</span>
+      </li>
+      <li>
+        <span class="work-title">Farsight: A Physics-Driven Whole-Body Biometric System at Large Distance and Altitude</span><br>
+        <span class="work-venue">WACV 2024</span>
+      </li>
+      <li>
+        <span class="work-title">ROG-Grasp: Root-Oriented Geometry for Robotic Grasping and Placement</span><br>
+        <span class="work-venue">IEEE CASE 2026</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Where it applies</h2>
+    <div class="research-tags">
+      <span class="research-tag">Digital health</span>
+      <span class="research-tag">Fitness &amp; sports</span>
+      <span class="research-tag">Rehabilitation</span>
+      <span class="research-tag">Workforce training</span>
+      <span class="research-tag">Humanoid robotics</span>
+      <span class="research-tag">AR / VR &amp; virtual humans</span>
+      <span class="research-tag">Human factors &amp; defense</span>
+    </div>
+  </div>
+
+  <a class="research-back" href="{{ '/research/' | relative_url }}">&larr; All research</a>
+
+</div>

--- a/_pages/research-video.md
+++ b/_pages/research-video.md
@@ -1,0 +1,87 @@
+---
+layout: page
+permalink: /research/person-centric-video/
+title: Person-Centric Long-Duration Video Intelligence
+description:
+nav: false
+importance: 91
+---
+
+<div class="research-container">
+
+  <div class="research-hero">
+    <div class="research-eyebrow">Research Direction</div>
+    <h1>Person-Centric Long-Duration Video Intelligence</h1>
+    <p>In long, multi-camera, real-world video, can we persistently understand who a
+    person is, what they are doing, how they change over time, and which events deserve
+    attention?</p>
+  </div>
+
+  <div class="research-section">
+    <p>Real deployments produce far more video than anyone can watch. We build systems that
+    follow people through long, unconstrained, multi-camera and aerial-ground footage
+    &mdash; recognizing identity across time and viewpoint, reasoning about activities and
+    events, and surfacing the moments that matter. This unifies person recognition, video
+    understanding, and temporal reasoning into a single person-centric capability.</p>
+  </div>
+
+  <div class="research-section">
+    <h2>What we work on</h2>
+    <ul class="research-bullets">
+      <li>Persistent person understanding across long videos</li>
+      <li>Multimodal person tracking and recognition</li>
+      <li>Long-term activities, behaviors, and interactions</li>
+      <li>Video event memory and temporal reasoning</li>
+      <li>Person-centric video retrieval and summarization</li>
+      <li>Interactive video refinement and sensemaking</li>
+      <li>Weakly supervised video detection</li>
+      <li>Video prioritization, anomaly discovery, and corpus understanding</li>
+      <li>Multi-camera and aerial-ground video understanding</li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Selected work</h2>
+    <ul class="research-works">
+      <li>
+        <span class="work-title">HAMoBE: Hierarchical and Adaptive Mixture of Biometric Experts for Video-based Person Re-ID</span><br>
+        <span class="work-venue">ICCV 2025</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2602.18990" target="_blank">IDSelect: A RL-Based Cost-Aware Selection Agent for Video-based Multi-Modal Person Recognition</a></span><br>
+        <span class="work-venue">2026</span>
+      </li>
+      <li>
+        <span class="work-title">AG-VPReID: A Challenging Large-Scale Benchmark for Aerial-Ground Video-based Person Re-Identification</span><br>
+        <span class="work-venue">CVPR 2025</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2505.04616" target="_blank">Person Recognition at Altitude and Range: Fusion of Face, Body Shape and Gait</a></span><br>
+        <span class="work-venue">2025</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2602.01012" target="_blank">LocalScore: Local Density-Aware Similarity Scoring for Biometrics</a></span><br>
+        <span class="work-venue">2026</span>
+      </li>
+      <li>
+        <span class="work-title">Person Recognition in Aerial Surveillance: A Decade Survey</span><br>
+        <span class="work-venue">IEEE T-BIOM 2025</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="research-section">
+    <h2>Where it applies</h2>
+    <div class="research-tags">
+      <span class="research-tag">Public safety</span>
+      <span class="research-tag">Defense &amp; ISR</span>
+      <span class="research-tag">Aerial-ground surveillance</span>
+      <span class="research-tag">Large-scale video analytics</span>
+      <span class="research-tag">Forensics</span>
+      <span class="research-tag">Smart infrastructure</span>
+    </div>
+  </div>
+
+  <a class="research-back" href="{{ '/research/' | relative_url }}">&larr; All research</a>
+
+</div>

--- a/_pages/research-video.md
+++ b/_pages/research-video.md
@@ -44,7 +44,7 @@ importance: 91
     <h2>Selected work</h2>
     <ul class="research-works">
       <li>
-        <span class="work-title">HAMoBE: Hierarchical and Adaptive Mixture of Biometric Experts for Video-based Person Re-ID</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2508.05038" target="_blank">HAMoBE: Hierarchical and Adaptive Mixture of Biometric Experts for Video-based Person Re-ID</a></span><br>
         <span class="work-venue">ICCV 2025</span>
       </li>
       <li>
@@ -52,7 +52,7 @@ importance: 91
         <span class="work-venue">2026</span>
       </li>
       <li>
-        <span class="work-title">AG-VPReID: A Challenging Large-Scale Benchmark for Aerial-Ground Video-based Person Re-Identification</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2503.08121" target="_blank">AG-VPReID: A Challenging Large-Scale Benchmark for Aerial-Ground Video-based Person Re-Identification</a></span><br>
         <span class="work-venue">CVPR 2025</span>
       </li>
       <li>
@@ -64,7 +64,7 @@ importance: 91
         <span class="work-venue">2026</span>
       </li>
       <li>
-        <span class="work-title">Person Recognition in Aerial Surveillance: A Decade Survey</span><br>
+        <span class="work-title"><a href="https://arxiv.org/abs/2511.17674" target="_blank">Person Recognition in Aerial Surveillance: A Decade Survey</a></span><br>
         <span class="work-venue">IEEE T-BIOM 2025</span>
       </li>
     </ul>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,0 +1,118 @@
+---
+layout: page
+permalink: /research/
+title: Research
+description:
+nav: true
+importance: 0
+---
+
+<div class="research-container">
+
+  <div class="research-hero">
+    <div class="research-eyebrow">Visual Intelligence Lab &middot; Drexel University</div>
+    <h1>Visual Intelligence for Humans and the Physical World</h1>
+    <p>We develop AI that understands, models, generates, and evaluates humans and the
+    physical world &mdash; connecting foundational computer vision with health, education,
+    robotics, and trustworthy AI.</p>
+  </div>
+
+  <!-- ===================== Research Directions ===================== -->
+  <div class="research-group-header">
+    <h2>Research Directions</h2>
+    <p class="research-group-sub">Core technical and scientific questions that define our lab.</p>
+  </div>
+
+  <div class="research-grid">
+
+    <a class="research-card" href="{{ '/research/physical-human-intelligence/' | relative_url }}">
+      <h3>Physical Human Intelligence</h3>
+      <p>Modeling, understanding, and generating the human body, motion, and its
+      interaction with the physical world &mdash; from images and video.</p>
+      <div class="research-tags">
+        <span class="research-tag">3D human</span>
+        <span class="research-tag">biomechanics</span>
+        <span class="research-tag">motion &amp; skill</span>
+        <span class="research-tag">embodied AI</span>
+      </div>
+      <span class="research-more">Learn more &rarr;</span>
+    </a>
+
+    <a class="research-card" href="{{ '/research/person-centric-video/' | relative_url }}">
+      <h3>Person-Centric Long-Duration Video Intelligence</h3>
+      <p>Persistently understanding who a person is, what they do, and how they change
+      across long, multi-camera, real-world video.</p>
+      <div class="research-tags">
+        <span class="research-tag">video Re-ID</span>
+        <span class="research-tag">temporal reasoning</span>
+        <span class="research-tag">aerial-ground</span>
+        <span class="research-tag">anomaly discovery</span>
+      </div>
+      <span class="research-more">Learn more &rarr;</span>
+    </a>
+
+    <a class="research-card" href="{{ '/research/biometrics-digital-identity/' | relative_url }}">
+      <h3>Trustworthy Biometrics and Digital Identity</h3>
+      <p>Creating, recognizing, and protecting human identity in a world increasingly
+      populated by synthetic people, avatars, and AI-generated media.</p>
+      <div class="research-tags">
+        <span class="research-tag">face / body / gait</span>
+        <span class="research-tag">deepfake detection</span>
+        <span class="research-tag">synthetic identity</span>
+        <span class="research-tag">open-set</span>
+      </div>
+      <span class="research-more">Learn more &rarr;</span>
+    </a>
+
+    <a class="research-card" href="{{ '/research/generative-multimodal-ai/' | relative_url }}">
+      <h3>Generative and Multimodal AI for the Physical World</h3>
+      <p>Geometry-consistent, physically plausible, and controllable generation and
+      multimodal reasoning over 3D, video, and language.</p>
+      <div class="research-tags">
+        <span class="research-tag">3D generation</span>
+        <span class="research-tag">VLMs</span>
+        <span class="research-tag">simulation</span>
+        <span class="research-tag">domain generalization</span>
+      </div>
+      <span class="research-more">Learn more &rarr;</span>
+    </a>
+
+  </div>
+
+  <!-- ===================== Impact Areas ===================== -->
+  <div class="research-group-header">
+    <h2>Impact Areas</h2>
+    <p class="research-group-sub">Where our core capabilities translate into real-world outcomes.</p>
+  </div>
+
+  <div class="research-grid">
+
+    <a class="research-card" href="{{ '/research/ai-health-human-performance/' | relative_url }}">
+      <h3>AI for Health and Human Performance</h3>
+      <p>Interpretable, video-based digital biomarkers that quantify how a person moves,
+      changes over time, and responds to intervention.</p>
+      <div class="research-tags">
+        <span class="research-tag">clinical gait</span>
+        <span class="research-tag">rehabilitation</span>
+        <span class="research-tag">coaching</span>
+        <span class="research-tag">remote assessment</span>
+      </div>
+      <span class="research-more">Learn more &rarr;</span>
+    </a>
+
+    <a class="research-card" href="{{ '/research/ai-education-scientific-learning/' | relative_url }}">
+      <h3>AI for Education and Scientific Learning</h3>
+      <p>Multimodal AI that reasons about student thinking, instructional practice, and
+      the evidence educators use to make decisions.</p>
+      <div class="research-tags">
+        <span class="research-tag">classroom video</span>
+        <span class="research-tag">student drawings</span>
+        <span class="research-tag">teacher feedback</span>
+        <span class="research-tag">pedagogical reasoning</span>
+      </div>
+      <span class="research-more">Learn more &rarr;</span>
+    </a>
+
+  </div>
+
+</div>

--- a/_sass/_research.scss
+++ b/_sass/_research.scss
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Styles for the Research pages (landing + detail)
+ ******************************************************************************/
+
+$research-accent-a: #667eea;
+$research-accent-b: #764ba2;
+
+.research-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+/* Intro / vision banner (shared by landing and detail pages) */
+.research-hero {
+  background: linear-gradient(135deg, $research-accent-a 0%, $research-accent-b 100%);
+  color: #fff;
+  padding: 34px 36px;
+  border-radius: 12px;
+  margin-bottom: 40px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.12);
+
+  .research-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.78em;
+    opacity: 0.85;
+    margin-bottom: 10px;
+  }
+
+  h1 {
+    margin: 0 0 14px 0;
+    font-size: 1.7em;
+    font-weight: 600;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    font-size: 1.08em;
+    line-height: 1.6;
+    opacity: 0.96;
+  }
+}
+
+/* Group heading, e.g. "Research Directions" / "Impact Areas" */
+.research-group-header {
+  border-left: 4px solid $research-accent-a;
+  padding-left: 18px;
+  margin: 44px 0 22px 0;
+
+  h2 {
+    margin: 0 0 4px 0;
+    font-size: 1.35em;
+    font-weight: 600;
+    color: var(--global-text-color);
+  }
+
+  .research-group-sub {
+    margin: 0;
+    color: var(--global-text-color-light);
+    font-size: 0.95em;
+  }
+}
+
+/* Grid of topic cards on the landing page */
+.research-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+
+.research-card {
+  display: block;
+  background: var(--global-bg-color);
+  border: 1px solid rgba(102, 126, 234, 0.22);
+  border-left: 4px solid $research-accent-a;
+  border-radius: 12px;
+  padding: 22px 24px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  color: var(--global-text-color);
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 22px rgba(102, 126, 234, 0.18);
+    text-decoration: none;
+    color: var(--global-text-color);
+  }
+
+  h3 {
+    margin: 0 0 10px 0;
+    font-size: 1.12em;
+    font-weight: 600;
+    color: var(--global-theme-color);
+  }
+
+  p {
+    margin: 0 0 14px 0;
+    color: var(--global-text-color);
+    line-height: 1.55;
+    font-size: 0.96em;
+  }
+
+  .research-more {
+    font-size: 0.9em;
+    font-weight: 600;
+    color: $research-accent-a;
+  }
+}
+
+/* Tag chips (capabilities / sectors) */
+.research-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 0 0 14px 0;
+}
+
+.research-tag {
+  background: rgba(102, 126, 234, 0.10);
+  color: var(--global-theme-color);
+  border: 1px solid rgba(102, 126, 234, 0.22);
+  border-radius: 999px;
+  padding: 3px 12px;
+  font-size: 0.8em;
+  line-height: 1.5;
+}
+
+/* Detail-page content sections */
+.research-section {
+  margin: 36px 0;
+
+  h2 {
+    font-size: 1.25em;
+    font-weight: 600;
+    color: var(--global-text-color);
+    border-bottom: 2px solid rgba(102, 126, 234, 0.25);
+    padding-bottom: 8px;
+    margin-bottom: 18px;
+  }
+}
+
+.research-bullets {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    position: relative;
+    padding: 8px 0 8px 26px;
+    line-height: 1.55;
+    color: var(--global-text-color);
+    border-bottom: 1px solid rgba(128, 128, 128, 0.14);
+
+    &:last-child { border-bottom: none; }
+
+    &::before {
+      content: "▹";
+      position: absolute;
+      left: 4px;
+      color: $research-accent-a;
+      font-weight: 700;
+    }
+  }
+}
+
+/* Selected work list */
+.research-works {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    padding: 12px 0;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.14);
+    line-height: 1.5;
+
+    &:last-child { border-bottom: none; }
+  }
+
+  .work-title { font-weight: 600; color: var(--global-text-color); }
+  .work-title a { color: var(--global-theme-color); }
+  .work-venue { color: var(--global-text-color-light); font-size: 0.9em; }
+}
+
+.research-note {
+  background: rgba(102, 126, 234, 0.08);
+  border-left: 3px solid $research-accent-a;
+  border-radius: 6px;
+  padding: 14px 18px;
+  margin: 20px 0;
+  color: var(--global-text-color);
+  line-height: 1.55;
+  font-size: 0.96em;
+}
+
+.research-back {
+  display: inline-block;
+  margin: 30px 0 10px 0;
+  font-weight: 600;
+  color: $research-accent-a;
+}
+
+@media (max-width: 768px) {
+  .research-container { padding: 15px; }
+  .research-hero { padding: 26px 22px; }
+  .research-grid { grid-template-columns: 1fr; }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,5 +11,6 @@ $max-content-width: {{site.max_width}};
   "themes",
   "layout",
   "base",
-  "distill"
+  "distill",
+  "research"
 ;


### PR DESCRIPTION
## Summary

Adds a new top-level **Research** tab (placed right after **About** in the navbar) aimed at helping potential sponsors quickly understand the lab's work. It presents the research as **four core Research Directions** plus **two Impact Areas**, each with its own detail page.

Navbar order after this change: `About → Research → Publications → Teaching → Awards & Services → Lab` (via `importance: 0` on the landing page; no other pages modified).

## Structure

Landing page `/research/` with short topic cards grouped into two sections, each linking to a detail page:

**Research Directions**
- Physical Human Intelligence — `/research/physical-human-intelligence/`
- Person-Centric Long-Duration Video Intelligence — `/research/person-centric-video/`
- Trustworthy Biometrics and Digital Identity — `/research/biometrics-digital-identity/`
- Generative and Multimodal AI for the Physical World — `/research/generative-multimodal-ai/`

**Impact Areas**
- AI for Health and Human Performance — `/research/ai-health-human-performance/`
- AI for Education and Scientific Learning — `/research/ai-education-scientific-learning/`

Each detail page follows the same layout: a problem statement, "What we work on" (capabilities), "Selected work" (flagship papers linked to arXiv / project pages), and "Where it applies" (application sectors).

## Implementation notes

- **Styling**: shared `_sass/_research.scss` partial, driven by the site's theme CSS variables so it renders correctly in both light and dark mode, wired into `assets/css/main.scss`.
- **Paper links**: sourced from `_bibliography/papers.bib` where available and otherwise from verified arXiv listings. The ICLS 2023 student-drawing paper has no preprint and is intentionally left as text.
- **Build**: verified with a full `jekyll build` (Ruby 3.2.6, matching the deploy workflow). `_site/` is intentionally not committed — the deploy workflow rebuilds it and publishes to `gh-pages`.

## Files
- `_pages/research.md` (landing) + six `_pages/research-*.md` detail pages
- `_sass/_research.scss`
- `assets/css/main.scss` (import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_