### PR TITLE
update

### DIFF
--- a/_pages/research-biometrics.md
+++ b/_pages/research-biometrics.md
@@ -7,27 +7,20 @@ nav: false
 importance: 92
 ---
 
-<div class="research-container">
+<div class="research">
 
-  <div class="research-hero">
-    <div class="research-eyebrow">Research Direction</div>
-    <h1>Trustworthy Biometrics and Digital Identity</h1>
-    <p>How do we create, recognize, and protect human identity in a world increasingly
-    populated by synthetic people, avatars, and AI-generated media?</p>
-  </div>
+  <p class="research-problem">How do we create, recognize, and protect human identity in a world
+  increasingly populated by synthetic people, avatars, and AI-generated media?</p>
 
-  <div class="research-section">
-    <p>Our longest and most cited line of work spans face, body, and gait recognition;
-    open-set and large-scale identification; long-range and aerial recognition; deepfake
-    detection; and synthetic identity. As digital entities and AI-generated media
-    proliferate, we study how to recognize real people robustly, generate identity-aware
-    synthetic data, detect manipulation, and provision secure identity &mdash; with
-    fairness, privacy, and explainability built in.</p>
-  </div>
+  <p>Our longest and most cited line of work spans face, body, and gait recognition; open-set and
+  large-scale identification; long-range and aerial recognition; deepfake detection; and synthetic
+  identity. As digital entities and AI-generated media proliferate, we study how to recognize real
+  people robustly, generate identity-aware synthetic data, detect manipulation, and provision secure
+  identity &mdash; with fairness, privacy, and explainability built in.</p>
 
   <div class="research-section">
     <h2>What we work on</h2>
-    <ul class="research-bullets">
+    <ul class="bullets">
       <li>Face, body, gait, and multimodal biometrics</li>
       <li>Open-set and large-scale recognition</li>
       <li>Long-range and aerial person recognition</li>
@@ -43,7 +36,7 @@ importance: 92
 
   <div class="research-section">
     <h2>Selected work</h2>
-    <ul class="research-works">
+    <ul class="works">
       <li>
         <span class="work-title"><a href="https://arxiv.org/abs/1910.01717" target="_blank">On the Detection of Digital Face Manipulation</a></span><br>
         <span class="work-venue">CVPR 2020</span>
@@ -73,14 +66,14 @@ importance: 92
 
   <div class="research-section">
     <h2>Where it applies</h2>
-    <div class="research-tags">
-      <span class="research-tag">Identity verification</span>
-      <span class="research-tag">Fraud prevention</span>
-      <span class="research-tag">Content authenticity &amp; provenance</span>
-      <span class="research-tag">Public safety &amp; defense</span>
-      <span class="research-tag">Synthetic-data generation</span>
-      <span class="research-tag">Privacy-preserving analytics</span>
-      <span class="research-tag">Avatar &amp; virtual-world identity</span>
+    <div class="tags">
+      <span class="tag">Identity verification</span>
+      <span class="tag">Fraud prevention</span>
+      <span class="tag">Content authenticity &amp; provenance</span>
+      <span class="tag">Public safety &amp; defense</span>
+      <span class="tag">Synthetic-data generation</span>
+      <span class="tag">Privacy-preserving analytics</span>
+      <span class="tag">Avatar &amp; virtual-world identity</span>
     </div>
   </div>
 

--- a/_pages/research-education.md
+++ b/_pages/research-education.md
@@ -7,26 +7,19 @@ nav: false
 importance: 95
 ---
 
-<div class="research-container">
+<div class="research">
 
-  <div class="research-hero">
-    <div class="research-eyebrow">Impact Area</div>
-    <h1>AI for Education and Scientific Learning</h1>
-    <p>We develop multimodal AI systems that reason about student thinking, instructional
-    practice, and the evidence educators use to make decisions.</p>
-  </div>
+  <p class="research-problem">We develop multimodal AI systems that reason about student thinking,
+  instructional practice, and the evidence educators use to make decisions.</p>
 
-  <div class="research-section">
-    <p>Our education research is not general-purpose tutoring or chatbots. It focuses on
-    the multimodal evidence of learning &mdash; classroom video, student scientific
-    drawings, and teacher decision-making &mdash; and on AI that does not merely recognize
-    classroom activity but reasons about student understanding, instructional quality, and
-    the evidence behind educational decisions.</p>
-  </div>
+  <p>Our education research is not general-purpose tutoring or chatbots. It focuses on the multimodal
+  evidence of learning &mdash; classroom video, student scientific drawings, and teacher
+  decision-making &mdash; and on AI that does not merely recognize classroom activity but reasons
+  about student understanding, instructional quality, and the evidence behind educational decisions.</p>
 
   <div class="research-section">
     <h2>What we work on</h2>
-    <ul class="research-bullets">
+    <ul class="bullets">
       <li>Multimodal understanding of classroom instruction</li>
       <li>AI-supported teacher feedback and decision-making</li>
       <li>Student drawing and scientific model assessment</li>
@@ -41,7 +34,7 @@ importance: 95
 
   <div class="research-section">
     <h2>Selected work</h2>
-    <ul class="research-works">
+    <ul class="works">
       <li>
         <span class="work-title"><a href="https://arxiv.org/abs/2602.18466" target="_blank">Can Multimodal LLMs See Science Instruction? Benchmarking Pedagogical Reasoning in K-12 Classroom Videos</a></span><br>
         <span class="work-venue">AIED 2026</span>
@@ -59,12 +52,12 @@ importance: 95
 
   <div class="research-section">
     <h2>Where it applies</h2>
-    <div class="research-tags">
-      <span class="research-tag">K-12 science education</span>
-      <span class="research-tag">Teacher professional development</span>
-      <span class="research-tag">Formative assessment</span>
-      <span class="research-tag">EdTech</span>
-      <span class="research-tag">Learning analytics</span>
+    <div class="tags">
+      <span class="tag">K-12 science education</span>
+      <span class="tag">Teacher professional development</span>
+      <span class="tag">Formative assessment</span>
+      <span class="tag">EdTech</span>
+      <span class="tag">Learning analytics</span>
     </div>
   </div>
 

--- a/_pages/research-generative.md
+++ b/_pages/research-generative.md
@@ -7,27 +7,20 @@ nav: false
 importance: 93
 ---
 
-<div class="research-container">
+<div class="research">
 
-  <div class="research-hero">
-    <div class="research-eyebrow">Research Direction</div>
-    <h1>Generative and Multimodal AI for the Physical World</h1>
-    <p>Can generative and multimodal models produce and reason about the physical world
-    with geometric and physical consistency &mdash; enough to drive perception,
-    simulation, and robotics?</p>
-  </div>
+  <p class="research-problem">Can generative and multimodal models produce and reason about the
+  physical world with geometric and physical consistency &mdash; enough to drive perception,
+  simulation, and robotics?</p>
 
-  <div class="research-section">
-    <p>We develop generative and multimodal models that respect the structure of the
-    physical world: 3D-aware and geometry-consistent generation, controllable synthesis,
-    and vision-language reasoning that generalizes across domains. These models produce
-    synthetic data for perception systems, power simulation for autonomous systems and
-    robotics, and increasingly run efficiently at the edge.</p>
-  </div>
+  <p>We develop generative and multimodal models that respect the structure of the physical world:
+  3D-aware and geometry-consistent generation, controllable synthesis, and vision-language reasoning
+  that generalizes across domains. These models produce synthetic data for perception systems, power
+  simulation for autonomous systems and robotics, and increasingly run efficiently at the edge.</p>
 
   <div class="research-section">
     <h2>What we work on</h2>
-    <ul class="research-bullets">
+    <ul class="bullets">
       <li>3D-aware and geometry-consistent generative models</li>
       <li>Controllable human and scene generation</li>
       <li>Synthetic data for perception systems</li>
@@ -41,7 +34,7 @@ importance: 93
 
   <div class="research-section">
     <h2>Selected work</h2>
-    <ul class="research-works">
+    <ul class="works">
       <li>
         <span class="work-title"><a href="https://cvlab.cse.msu.edu/pdfs/Ren_Kim_Liu_Liu_TIGER.pdf" target="_blank">TIGER: Time-Varying Denoising Model for 3D Point Cloud Generation with Diffusion Process</a></span><br>
         <span class="work-venue">CVPR 2024</span>
@@ -71,15 +64,15 @@ importance: 93
 
   <div class="research-section">
     <h2>Where it applies</h2>
-    <div class="research-tags">
-      <span class="research-tag">Autonomous driving</span>
-      <span class="research-tag">Robotics</span>
-      <span class="research-tag">Simulation &amp; synthetic data</span>
-      <span class="research-tag">Digital twins</span>
-      <span class="research-tag">Content creation</span>
-      <span class="research-tag">AR / VR</span>
-      <span class="research-tag">Edge AI</span>
-      <span class="research-tag">Scientific &amp; engineering design</span>
+    <div class="tags">
+      <span class="tag">Autonomous driving</span>
+      <span class="tag">Robotics</span>
+      <span class="tag">Simulation &amp; synthetic data</span>
+      <span class="tag">Digital twins</span>
+      <span class="tag">Content creation</span>
+      <span class="tag">AR / VR</span>
+      <span class="tag">Edge AI</span>
+      <span class="tag">Scientific &amp; engineering design</span>
     </div>
   </div>
 

--- a/_pages/research-health.md
+++ b/_pages/research-health.md
@@ -7,32 +7,25 @@ nav: false
 importance: 94
 ---
 
-<div class="research-container">
+<div class="research">
 
-  <div class="research-hero">
-    <div class="research-eyebrow">Impact Area</div>
-    <h1>AI for Health and Human Performance</h1>
-    <p>Current clinical assessments often rely on short observations, subjective scores, or
-    specialized equipment. We develop interpretable, video-based biomarkers that quantify
-    how an individual moves, changes over time, and responds to intervention.</p>
-  </div>
+  <p class="research-problem">Current clinical assessments often rely on short observations,
+  subjective scores, or specialized equipment. We develop interpretable, video-based biomarkers that
+  quantify how an individual moves, changes over time, and responds to intervention.</p>
 
-  <div class="research-section">
-    <p>This impact area applies our human-modeling and biomechanics research to health,
-    mobility, and human performance. We build interpretable systems &mdash; grounded in
-    biomechanics and explained in language clinicians and patients can act on &mdash; for
-    remote, unobtrusive, and longitudinal assessment.</p>
-    <div class="research-note">
-      <strong>How this differs from Physical Human Intelligence:</strong> Physical Human
-      Intelligence asks <em>how</em> machines can understand human bodies and movement.
-      AI for Health and Human Performance <em>applies</em> those capabilities to mobility,
-      rehabilitation, disease monitoring, coaching, and personalized assessment.
-    </div>
-  </div>
+  <p>This impact area applies our human-modeling and biomechanics research to health, mobility, and
+  human performance. We build interpretable systems &mdash; grounded in biomechanics and explained in
+  language clinicians and patients can act on &mdash; for remote, unobtrusive, and longitudinal
+  assessment.</p>
+
+  <p class="research-note"><strong>How this differs from Physical Human Intelligence:</strong>
+  Physical Human Intelligence asks <em>how</em> machines can understand human bodies and movement.
+  AI for Health and Human Performance <em>applies</em> those capabilities to mobility, rehabilitation,
+  disease monitoring, coaching, and personalized assessment.</p>
 
   <div class="research-section">
     <h2>What we work on</h2>
-    <ul class="research-bullets">
+    <ul class="bullets">
       <li>Video-based digital biomarkers</li>
       <li>Clinical gait and mobility assessment</li>
       <li>Longitudinal tracking of disease and recovery</li>
@@ -48,7 +41,7 @@ importance: 94
 
   <div class="research-section">
     <h2>Selected work</h2>
-    <ul class="research-works">
+    <ul class="works">
       <li>
         <span class="work-title"><a href="https://arxiv.org/abs/2603.08564" target="_blank">BioGait-VLM: A Tri-Modal Vision-Language-Biomechanics Framework for Interpretable Clinical Gait Assessment</a></span><br>
         <span class="work-venue">MICCAI 2026</span>
@@ -62,14 +55,14 @@ importance: 94
 
   <div class="research-section">
     <h2>Where it applies</h2>
-    <div class="research-tags">
-      <span class="research-tag">Hospitals &amp; clinics</span>
-      <span class="research-tag">Rehabilitation</span>
-      <span class="research-tag">Medical devices</span>
-      <span class="research-tag">Clinical trials</span>
-      <span class="research-tag">Sports medicine</span>
-      <span class="research-tag">Remote patient monitoring</span>
-      <span class="research-tag">Defense medical &amp; readiness</span>
+    <div class="tags">
+      <span class="tag">Hospitals &amp; clinics</span>
+      <span class="tag">Rehabilitation</span>
+      <span class="tag">Medical devices</span>
+      <span class="tag">Clinical trials</span>
+      <span class="tag">Sports medicine</span>
+      <span class="tag">Remote patient monitoring</span>
+      <span class="tag">Defense medical &amp; readiness</span>
     </div>
   </div>
 

--- a/_pages/research-human.md
+++ b/_pages/research-human.md
@@ -7,27 +7,20 @@ nav: false
 importance: 90
 ---
 
-<div class="research-container">
+<div class="research">
 
-  <div class="research-hero">
-    <div class="research-eyebrow">Research Direction</div>
-    <h1>Physical Human Intelligence</h1>
-    <p>How can machines understand the human body &mdash; its shape, motion, and
-    biomechanics &mdash; well enough to model, simulate, and reason about what a person
-    is doing and how well they do it?</p>
-  </div>
+  <p class="research-problem">How can machines understand the human body &mdash; its shape, motion, and
+  biomechanics &mdash; well enough to model, simulate, and reason about what a person is doing and
+  how well they do it?</p>
 
-  <div class="research-section">
-    <p>We build models that recover and reason about the human body from images and video:
-    its 3D geometry, pose, motion, appearance, and biomechanical state. The goal is not
-    pose estimation alone, but a complete physical understanding of people &mdash; their
-    movement, skill, and interaction with the world &mdash; that can drive digital humans,
-    health, and embodied AI.</p>
-  </div>
+  <p>We build models that recover and reason about the human body from images and video: its 3D
+  geometry, pose, motion, appearance, and biomechanical state. The goal is not pose estimation
+  alone, but a complete physical understanding of people &mdash; their movement, skill, and
+  interaction with the world &mdash; that can drive digital humans, health, and embodied AI.</p>
 
   <div class="research-section">
     <h2>What we work on</h2>
-    <ul class="research-bullets">
+    <ul class="bullets">
       <li>3D human reconstruction and digitization</li>
       <li>Human shape, pose, motion, and appearance modeling</li>
       <li>Biomechanics-grounded human understanding</li>
@@ -40,7 +33,7 @@ importance: 90
 
   <div class="research-section">
     <h2>Selected work</h2>
-    <ul class="research-works">
+    <ul class="works">
       <li>
         <span class="work-title"><a href="https://cvlab.cse.msu.edu/pdfs/Liu_Kim_Ren_Liu_CLIP3DREID.pdf" target="_blank">Distilling CLIP with Dual Guidance for Learning Discriminative Human Body Shape Representation</a></span><br>
         <span class="work-venue">CVPR 2024</span>
@@ -70,14 +63,14 @@ importance: 90
 
   <div class="research-section">
     <h2>Where it applies</h2>
-    <div class="research-tags">
-      <span class="research-tag">Digital health</span>
-      <span class="research-tag">Fitness &amp; sports</span>
-      <span class="research-tag">Rehabilitation</span>
-      <span class="research-tag">Workforce training</span>
-      <span class="research-tag">Humanoid robotics</span>
-      <span class="research-tag">AR / VR &amp; virtual humans</span>
-      <span class="research-tag">Human factors &amp; defense</span>
+    <div class="tags">
+      <span class="tag">Digital health</span>
+      <span class="tag">Fitness &amp; sports</span>
+      <span class="tag">Rehabilitation</span>
+      <span class="tag">Workforce training</span>
+      <span class="tag">Humanoid robotics</span>
+      <span class="tag">AR / VR &amp; virtual humans</span>
+      <span class="tag">Human factors &amp; defense</span>
     </div>
   </div>
 

--- a/_pages/research-video.md
+++ b/_pages/research-video.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 permalink: /research/person-centric-video/
-title: Person-Centric Long-Duration Video Intelligence
+title: Understanding People in Long, Real-World Video
 description:
 nav: false
 importance: 91
@@ -9,49 +9,38 @@ importance: 91
 
 <div class="research">
 
-  <p class="research-lede">Long-duration video from fixed, aerial, and body-worn cameras contains
-  brief, high-value moments buried in hours of routine footage. We develop the representations and
-  decision mechanisms needed to find, connect, and rank this evidence: persistent models of people
-  and their activities that survive clothing change, viewpoint shift, low resolution, and gaps across
-  cameras and time, paired with open-set uncertainty estimation that keeps false matches under
-  control.</p>
+  <p class="research-problem">In long, multi-camera, real-world video, can we persistently understand
+  who a person is, what they are doing, how they change over time, and which moments deserve
+  attention?</p>
+
+  <p>Real deployments produce far more video than anyone can watch. We build systems that follow
+  people through long, unconstrained, multi-camera and aerial-ground footage: recognizing identity
+  across time, clothing, and viewpoint, interpreting activities and motion, and deciding which
+  evidence is reliable enough to act on and which needs a human's judgment.</p>
 
   <div class="research-section">
-    <h2>Three strands of one program</h2>
-
-    <div class="thread">
-      <div class="thread-title">Persistent person representation</div>
-      <p>Multi-cue models combining appearance, 3D body shape, and motion for identification and
-      retrieval in long, fragmented video &mdash; including clothing- and pose-invariant 3D shape
-      representations and recognition at long range and from elevated platforms.</p>
-    </div>
-
-    <div class="thread">
-      <div class="thread-title">Open-set recognition and uncertainty</div>
-      <p>Identification-detection formulations, threshold learning, and calibrated confidence for
-      deciding when a match should be accepted, deferred to a human, or rejected &mdash; the core
-      requirement for retrieval and alerting systems that avoid false-alarm fatigue.</p>
-    </div>
-
-    <div class="thread">
-      <div class="thread-title">Motion as interpretable evidence</div>
-      <p>Vision-language systems that convert fine-grained human motion in unconstrained video into
-      structured, interpretable semantic descriptions rather than coarse action labels, supporting
-      downstream reasoning and human review.</p>
-    </div>
+    <h2>What we work on</h2>
+    <ul class="bullets">
+      <li>Persistent person understanding across long videos</li>
+      <li>Multimodal person recognition combining appearance, 3D body shape, and gait</li>
+      <li>Multi-camera and aerial-ground video understanding</li>
+      <li>Open-set recognition and uncertainty-aware matching</li>
+      <li>Person-centric video retrieval and ranking</li>
+      <li>Cost-aware evidence selection for video analysis</li>
+      <li>Human motion as interpretable, language-grounded evidence</li>
+    </ul>
   </div>
 
   <div class="research-section">
-    <h2>Ongoing directions</h2>
-    <p>We are extending this foundation toward interactive video triage: learning a user's evolving
-    objectives from sparse, natural feedback such as example clips and short natural-language
-    corrections, propagating that feedback through persistent person- and activity-centric indexes,
-    and prioritizing large unreviewed video collections with calibrated confidence and abstention.
-    Recent work on reinforcement-learned, cost-aware model selection for video-based person
-    recognition (<a href="https://arxiv.org/abs/2602.18990" target="_blank">IDSelect</a>, 2026) is a
-    first step toward systems that decide, per clip, which evidence is worth computing and which
-    results are worth a human's attention. The goal is a system a non-technical user can teach
-    through ordinary review behavior, without ever drawing a bounding box.</p>
+    <h2>Emerging directions</h2>
+    <p>We are extending this line toward video analysis that non-expert users can steer. Rather than
+    requiring labeled data or precisely specified queries, we want systems that infer what a user is
+    looking for from a few example clips, short corrections, and ordinary review behavior, then
+    reorganize large unwatched collections accordingly: surfacing likely-relevant moments, flagging
+    the unexpected, and knowing when to defer to human judgment. Our recent work on cost-aware model
+    selection (<a href="https://arxiv.org/abs/2602.18990" target="_blank">IDSelect</a>) is a first
+    step &mdash; a system that decides, per video, which evidence is worth computing and which results
+    are worth a person's attention.</p>
   </div>
 
   <div class="research-section">
@@ -74,12 +63,16 @@ importance: 91
         <span class="work-venue">CVPR 2025</span>
       </li>
       <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2407.16133" target="_blank">Open-Set Biometrics: Beyond Good Closed-Set Models</a></span><br>
+        <span class="work-venue">ECCV 2024</span>
+      </li>
+      <li>
         <span class="work-title"><a href="https://arxiv.org/abs/2503.08121" target="_blank">AG-VPReID: A Challenging Large-Scale Benchmark for Aerial-Ground Video-based Person Re-Identification</a></span><br>
         <span class="work-venue">CVPR 2025</span>
       </li>
       <li>
-        <span class="work-title"><a href="https://arxiv.org/abs/2407.16133" target="_blank">Open-Set Biometrics: Beyond Good Closed-Set Models</a></span><br>
-        <span class="work-venue">ECCV 2024</span>
+        <span class="work-title"><a href="https://arxiv.org/abs/2602.18990" target="_blank">IDSelect: A RL-Based Cost-Aware Selection Agent for Video-based Multi-Modal Person Recognition</a></span><br>
+        <span class="work-venue">2026</span>
       </li>
       <li>
         <span class="work-title"><a href="https://arxiv.org/abs/2603.26938" target="_blank">From 3D Pose to Prose: Biomechanics-Grounded Vision&ndash;Language Coaching</a></span><br>
@@ -96,17 +89,12 @@ importance: 91
     <h2>Where it applies</h2>
     <div class="tags">
       <span class="tag">Public safety</span>
-      <span class="tag">Defense &amp; ISR</span>
-      <span class="tag">Aerial-ground surveillance</span>
+      <span class="tag">Defense and national security</span>
       <span class="tag">Large-scale video analytics</span>
       <span class="tag">Forensics</span>
-      <span class="tag">Interactive video triage</span>
+      <span class="tag">Smart infrastructure</span>
     </div>
   </div>
-
-  <p class="research-sponsors">This research thread has been supported in part by the IARPA BRIAR
-  program and other federal sponsors. Sponsor acknowledgments follow the language used in the
-  corresponding publications.</p>
 
   <a class="research-back" href="{{ '/research/' | relative_url }}">&larr; All research</a>
 

--- a/_pages/research-video.md
+++ b/_pages/research-video.md
@@ -9,29 +9,49 @@ importance: 91
 
 <div class="research">
 
-  <p class="research-problem">In long, multi-camera, real-world video, can we persistently understand
-  who a person is, what they are doing, how they change over time, and which events deserve
-  attention?</p>
-
-  <p>Real deployments produce far more video than anyone can watch. We build systems that follow
-  people through long, unconstrained, multi-camera and aerial-ground footage &mdash; recognizing
-  identity across time and viewpoint, reasoning about activities and events, and surfacing the
-  moments that matter. This unifies person recognition, video understanding, and temporal reasoning
-  into a single person-centric capability.</p>
+  <p class="research-lede">Long-duration video from fixed, aerial, and body-worn cameras contains
+  brief, high-value moments buried in hours of routine footage. We develop the representations and
+  decision mechanisms needed to find, connect, and rank this evidence: persistent models of people
+  and their activities that survive clothing change, viewpoint shift, low resolution, and gaps across
+  cameras and time, paired with open-set uncertainty estimation that keeps false matches under
+  control.</p>
 
   <div class="research-section">
-    <h2>What we work on</h2>
-    <ul class="bullets">
-      <li>Persistent person understanding across long videos</li>
-      <li>Multimodal person tracking and recognition</li>
-      <li>Long-term activities, behaviors, and interactions</li>
-      <li>Video event memory and temporal reasoning</li>
-      <li>Person-centric video retrieval and summarization</li>
-      <li>Interactive video refinement and sensemaking</li>
-      <li>Weakly supervised video detection</li>
-      <li>Video prioritization, anomaly discovery, and corpus understanding</li>
-      <li>Multi-camera and aerial-ground video understanding</li>
-    </ul>
+    <h2>Three strands of one program</h2>
+
+    <div class="thread">
+      <div class="thread-title">Persistent person representation</div>
+      <p>Multi-cue models combining appearance, 3D body shape, and motion for identification and
+      retrieval in long, fragmented video &mdash; including clothing- and pose-invariant 3D shape
+      representations and recognition at long range and from elevated platforms.</p>
+    </div>
+
+    <div class="thread">
+      <div class="thread-title">Open-set recognition and uncertainty</div>
+      <p>Identification-detection formulations, threshold learning, and calibrated confidence for
+      deciding when a match should be accepted, deferred to a human, or rejected &mdash; the core
+      requirement for retrieval and alerting systems that avoid false-alarm fatigue.</p>
+    </div>
+
+    <div class="thread">
+      <div class="thread-title">Motion as interpretable evidence</div>
+      <p>Vision-language systems that convert fine-grained human motion in unconstrained video into
+      structured, interpretable semantic descriptions rather than coarse action labels, supporting
+      downstream reasoning and human review.</p>
+    </div>
+  </div>
+
+  <div class="research-section">
+    <h2>Ongoing directions</h2>
+    <p>We are extending this foundation toward interactive video triage: learning a user's evolving
+    objectives from sparse, natural feedback such as example clips and short natural-language
+    corrections, propagating that feedback through persistent person- and activity-centric indexes,
+    and prioritizing large unreviewed video collections with calibrated confidence and abstention.
+    Recent work on reinforcement-learned, cost-aware model selection for video-based person
+    recognition (<a href="https://arxiv.org/abs/2602.18990" target="_blank">IDSelect</a>, 2026) is a
+    first step toward systems that decide, per clip, which evidence is worth computing and which
+    results are worth a human's attention. The goal is a system a non-technical user can teach
+    through ordinary review behavior, without ever drawing a bounding box.</p>
   </div>
 
   <div class="research-section">
@@ -42,20 +62,28 @@ importance: 91
         <span class="work-venue">ICCV 2025</span>
       </li>
       <li>
-        <span class="work-title"><a href="https://arxiv.org/abs/2602.18990" target="_blank">IDSelect: A RL-Based Cost-Aware Selection Agent for Video-based Multi-Modal Person Recognition</a></span><br>
-        <span class="work-venue">2026</span>
+        <span class="work-title"><a href="https://arxiv.org/abs/2308.10658" target="_blank">Learning Clothing and Pose Invariant 3D Shape Representation for Long-Term Person Re-Identification</a></span><br>
+        <span class="work-venue">ICCV 2023</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2306.17206" target="_blank">FarSight: A Physics-Driven Whole-Body Biometric System at Large Distance and Altitude</a></span><br>
+        <span class="work-venue">WACV 2024</span>
+      </li>
+      <li>
+        <span class="work-title"><a href="https://arxiv.org/abs/2504.04708" target="_blank">SapiensID: Foundation for Human Recognition</a></span><br>
+        <span class="work-venue">CVPR 2025</span>
       </li>
       <li>
         <span class="work-title"><a href="https://arxiv.org/abs/2503.08121" target="_blank">AG-VPReID: A Challenging Large-Scale Benchmark for Aerial-Ground Video-based Person Re-Identification</a></span><br>
         <span class="work-venue">CVPR 2025</span>
       </li>
       <li>
-        <span class="work-title"><a href="https://arxiv.org/abs/2505.04616" target="_blank">Person Recognition at Altitude and Range: Fusion of Face, Body Shape and Gait</a></span><br>
-        <span class="work-venue">2025</span>
+        <span class="work-title"><a href="https://arxiv.org/abs/2407.16133" target="_blank">Open-Set Biometrics: Beyond Good Closed-Set Models</a></span><br>
+        <span class="work-venue">ECCV 2024</span>
       </li>
       <li>
-        <span class="work-title"><a href="https://arxiv.org/abs/2602.01012" target="_blank">LocalScore: Local Density-Aware Similarity Scoring for Biometrics</a></span><br>
-        <span class="work-venue">2026</span>
+        <span class="work-title"><a href="https://arxiv.org/abs/2603.26938" target="_blank">From 3D Pose to Prose: Biomechanics-Grounded Vision&ndash;Language Coaching</a></span><br>
+        <span class="work-venue">CVPR 2026</span>
       </li>
       <li>
         <span class="work-title"><a href="https://arxiv.org/abs/2511.17674" target="_blank">Person Recognition in Aerial Surveillance: A Decade Survey</a></span><br>
@@ -72,9 +100,13 @@ importance: 91
       <span class="tag">Aerial-ground surveillance</span>
       <span class="tag">Large-scale video analytics</span>
       <span class="tag">Forensics</span>
-      <span class="tag">Smart infrastructure</span>
+      <span class="tag">Interactive video triage</span>
     </div>
   </div>
+
+  <p class="research-sponsors">This research thread has been supported in part by the IARPA BRIAR
+  program and other federal sponsors. Sponsor acknowledgments follow the language used in the
+  corresponding publications.</p>
 
   <a class="research-back" href="{{ '/research/' | relative_url }}">&larr; All research</a>
 

--- a/_pages/research-video.md
+++ b/_pages/research-video.md
@@ -7,27 +7,21 @@ nav: false
 importance: 91
 ---
 
-<div class="research-container">
+<div class="research">
 
-  <div class="research-hero">
-    <div class="research-eyebrow">Research Direction</div>
-    <h1>Person-Centric Long-Duration Video Intelligence</h1>
-    <p>In long, multi-camera, real-world video, can we persistently understand who a
-    person is, what they are doing, how they change over time, and which events deserve
-    attention?</p>
-  </div>
+  <p class="research-problem">In long, multi-camera, real-world video, can we persistently understand
+  who a person is, what they are doing, how they change over time, and which events deserve
+  attention?</p>
 
-  <div class="research-section">
-    <p>Real deployments produce far more video than anyone can watch. We build systems that
-    follow people through long, unconstrained, multi-camera and aerial-ground footage
-    &mdash; recognizing identity across time and viewpoint, reasoning about activities and
-    events, and surfacing the moments that matter. This unifies person recognition, video
-    understanding, and temporal reasoning into a single person-centric capability.</p>
-  </div>
+  <p>Real deployments produce far more video than anyone can watch. We build systems that follow
+  people through long, unconstrained, multi-camera and aerial-ground footage &mdash; recognizing
+  identity across time and viewpoint, reasoning about activities and events, and surfacing the
+  moments that matter. This unifies person recognition, video understanding, and temporal reasoning
+  into a single person-centric capability.</p>
 
   <div class="research-section">
     <h2>What we work on</h2>
-    <ul class="research-bullets">
+    <ul class="bullets">
       <li>Persistent person understanding across long videos</li>
       <li>Multimodal person tracking and recognition</li>
       <li>Long-term activities, behaviors, and interactions</li>
@@ -42,7 +36,7 @@ importance: 91
 
   <div class="research-section">
     <h2>Selected work</h2>
-    <ul class="research-works">
+    <ul class="works">
       <li>
         <span class="work-title"><a href="https://arxiv.org/abs/2508.05038" target="_blank">HAMoBE: Hierarchical and Adaptive Mixture of Biometric Experts for Video-based Person Re-ID</a></span><br>
         <span class="work-venue">ICCV 2025</span>
@@ -72,13 +66,13 @@ importance: 91
 
   <div class="research-section">
     <h2>Where it applies</h2>
-    <div class="research-tags">
-      <span class="research-tag">Public safety</span>
-      <span class="research-tag">Defense &amp; ISR</span>
-      <span class="research-tag">Aerial-ground surveillance</span>
-      <span class="research-tag">Large-scale video analytics</span>
-      <span class="research-tag">Forensics</span>
-      <span class="research-tag">Smart infrastructure</span>
+    <div class="tags">
+      <span class="tag">Public safety</span>
+      <span class="tag">Defense &amp; ISR</span>
+      <span class="tag">Aerial-ground surveillance</span>
+      <span class="tag">Large-scale video analytics</span>
+      <span class="tag">Forensics</span>
+      <span class="tag">Smart infrastructure</span>
     </div>
   </div>
 

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -27,7 +27,7 @@ importance: 0
 
     <li class="topic">
       <div class="topic-head">
-        <a class="topic-title" href="{{ '/research/person-centric-video/' | relative_url }}">Person-Centric Long-Duration Video Intelligence</a>
+        <a class="topic-title" href="{{ '/research/person-centric-video/' | relative_url }}">Understanding People in Long, Real-World Video</a>
         <span class="topic-desc"> &mdash; Persistently understanding who a person is, what they do, and how they change across long, multi-camera, real-world video.</span>
       </div>
       <div class="topic-tags tags">

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,118 +1,100 @@
 ---
 layout: page
 permalink: /research/
-title: Research
+title: Research & Impact
 description:
 nav: true
 importance: 0
 ---
 
-<div class="research-container">
+<div class="research">
 
-  <div class="research-hero">
-    <div class="research-eyebrow">Visual Intelligence Lab &middot; Drexel University</div>
-    <h1>Visual Intelligence for Humans and the Physical World</h1>
-    <p>We develop AI that understands, models, generates, and evaluates humans and the
-    physical world &mdash; connecting foundational computer vision with health, education,
-    robotics, and trustworthy AI.</p>
-  </div>
+  <div class="research-group">Research Directions</div>
+  <ul class="topic-list">
 
-  <!-- ===================== Research Directions ===================== -->
-  <div class="research-group-header">
-    <h2>Research Directions</h2>
-    <p class="research-group-sub">Core technical and scientific questions that define our lab.</p>
-  </div>
-
-  <div class="research-grid">
-
-    <a class="research-card" href="{{ '/research/physical-human-intelligence/' | relative_url }}">
-      <h3>Physical Human Intelligence</h3>
-      <p>Modeling, understanding, and generating the human body, motion, and its
-      interaction with the physical world &mdash; from images and video.</p>
-      <div class="research-tags">
-        <span class="research-tag">3D human</span>
-        <span class="research-tag">biomechanics</span>
-        <span class="research-tag">motion &amp; skill</span>
-        <span class="research-tag">embodied AI</span>
+    <li class="topic">
+      <div class="topic-head">
+        <a class="topic-title" href="{{ '/research/physical-human-intelligence/' | relative_url }}">Physical Human Intelligence</a>
+        <span class="topic-desc"> &mdash; Modeling, understanding, and generating the human body, motion, and its interaction with the physical world, from images and video.</span>
       </div>
-      <span class="research-more">Learn more &rarr;</span>
-    </a>
-
-    <a class="research-card" href="{{ '/research/person-centric-video/' | relative_url }}">
-      <h3>Person-Centric Long-Duration Video Intelligence</h3>
-      <p>Persistently understanding who a person is, what they do, and how they change
-      across long, multi-camera, real-world video.</p>
-      <div class="research-tags">
-        <span class="research-tag">video Re-ID</span>
-        <span class="research-tag">temporal reasoning</span>
-        <span class="research-tag">aerial-ground</span>
-        <span class="research-tag">anomaly discovery</span>
+      <div class="topic-tags tags">
+        <span class="tag">3D human</span>
+        <span class="tag">biomechanics</span>
+        <span class="tag">motion &amp; skill</span>
+        <span class="tag">embodied AI</span>
       </div>
-      <span class="research-more">Learn more &rarr;</span>
-    </a>
+    </li>
 
-    <a class="research-card" href="{{ '/research/biometrics-digital-identity/' | relative_url }}">
-      <h3>Trustworthy Biometrics and Digital Identity</h3>
-      <p>Creating, recognizing, and protecting human identity in a world increasingly
-      populated by synthetic people, avatars, and AI-generated media.</p>
-      <div class="research-tags">
-        <span class="research-tag">face / body / gait</span>
-        <span class="research-tag">deepfake detection</span>
-        <span class="research-tag">synthetic identity</span>
-        <span class="research-tag">open-set</span>
+    <li class="topic">
+      <div class="topic-head">
+        <a class="topic-title" href="{{ '/research/person-centric-video/' | relative_url }}">Person-Centric Long-Duration Video Intelligence</a>
+        <span class="topic-desc"> &mdash; Persistently understanding who a person is, what they do, and how they change across long, multi-camera, real-world video.</span>
       </div>
-      <span class="research-more">Learn more &rarr;</span>
-    </a>
-
-    <a class="research-card" href="{{ '/research/generative-multimodal-ai/' | relative_url }}">
-      <h3>Generative and Multimodal AI for the Physical World</h3>
-      <p>Geometry-consistent, physically plausible, and controllable generation and
-      multimodal reasoning over 3D, video, and language.</p>
-      <div class="research-tags">
-        <span class="research-tag">3D generation</span>
-        <span class="research-tag">VLMs</span>
-        <span class="research-tag">simulation</span>
-        <span class="research-tag">domain generalization</span>
+      <div class="topic-tags tags">
+        <span class="tag">video Re-ID</span>
+        <span class="tag">temporal reasoning</span>
+        <span class="tag">aerial-ground</span>
+        <span class="tag">anomaly discovery</span>
       </div>
-      <span class="research-more">Learn more &rarr;</span>
-    </a>
+    </li>
 
-  </div>
-
-  <!-- ===================== Impact Areas ===================== -->
-  <div class="research-group-header">
-    <h2>Impact Areas</h2>
-    <p class="research-group-sub">Where our core capabilities translate into real-world outcomes.</p>
-  </div>
-
-  <div class="research-grid">
-
-    <a class="research-card" href="{{ '/research/ai-health-human-performance/' | relative_url }}">
-      <h3>AI for Health and Human Performance</h3>
-      <p>Interpretable, video-based digital biomarkers that quantify how a person moves,
-      changes over time, and responds to intervention.</p>
-      <div class="research-tags">
-        <span class="research-tag">clinical gait</span>
-        <span class="research-tag">rehabilitation</span>
-        <span class="research-tag">coaching</span>
-        <span class="research-tag">remote assessment</span>
+    <li class="topic">
+      <div class="topic-head">
+        <a class="topic-title" href="{{ '/research/biometrics-digital-identity/' | relative_url }}">Trustworthy Biometrics and Digital Identity</a>
+        <span class="topic-desc"> &mdash; Creating, recognizing, and protecting human identity in a world increasingly populated by synthetic people, avatars, and AI-generated media.</span>
       </div>
-      <span class="research-more">Learn more &rarr;</span>
-    </a>
-
-    <a class="research-card" href="{{ '/research/ai-education-scientific-learning/' | relative_url }}">
-      <h3>AI for Education and Scientific Learning</h3>
-      <p>Multimodal AI that reasons about student thinking, instructional practice, and
-      the evidence educators use to make decisions.</p>
-      <div class="research-tags">
-        <span class="research-tag">classroom video</span>
-        <span class="research-tag">student drawings</span>
-        <span class="research-tag">teacher feedback</span>
-        <span class="research-tag">pedagogical reasoning</span>
+      <div class="topic-tags tags">
+        <span class="tag">face / body / gait</span>
+        <span class="tag">deepfake detection</span>
+        <span class="tag">synthetic identity</span>
+        <span class="tag">open-set</span>
       </div>
-      <span class="research-more">Learn more &rarr;</span>
-    </a>
+    </li>
 
-  </div>
+    <li class="topic">
+      <div class="topic-head">
+        <a class="topic-title" href="{{ '/research/generative-multimodal-ai/' | relative_url }}">Generative and Multimodal AI for the Physical World</a>
+        <span class="topic-desc"> &mdash; Geometry-consistent, physically plausible, and controllable generation and multimodal reasoning over 3D, video, and language.</span>
+      </div>
+      <div class="topic-tags tags">
+        <span class="tag">3D generation</span>
+        <span class="tag">VLMs</span>
+        <span class="tag">simulation</span>
+        <span class="tag">domain generalization</span>
+      </div>
+    </li>
+
+  </ul>
+
+  <div class="research-group">Impact Areas</div>
+  <ul class="topic-list">
+
+    <li class="topic">
+      <div class="topic-head">
+        <a class="topic-title" href="{{ '/research/ai-health-human-performance/' | relative_url }}">AI for Health and Human Performance</a>
+        <span class="topic-desc"> &mdash; Interpretable, video-based digital biomarkers that quantify how a person moves, changes over time, and responds to intervention.</span>
+      </div>
+      <div class="topic-tags tags">
+        <span class="tag">clinical gait</span>
+        <span class="tag">rehabilitation</span>
+        <span class="tag">coaching</span>
+        <span class="tag">remote assessment</span>
+      </div>
+    </li>
+
+    <li class="topic">
+      <div class="topic-head">
+        <a class="topic-title" href="{{ '/research/ai-education-scientific-learning/' | relative_url }}">AI for Education and Scientific Learning</a>
+        <span class="topic-desc"> &mdash; Multimodal AI that reasons about student thinking, instructional practice, and the evidence educators use to make decisions.</span>
+      </div>
+      <div class="topic-tags tags">
+        <span class="tag">classroom video</span>
+        <span class="tag">student drawings</span>
+        <span class="tag">teacher feedback</span>
+        <span class="tag">pedagogical reasoning</span>
+      </div>
+    </li>
+
+  </ul>
 
 </div>

--- a/_sass/_research.scss
+++ b/_sass/_research.scss
@@ -168,6 +168,42 @@ $research-rule: rgba(128, 128, 128, 0.18);
     color: var(--global-text-color-light);
   }
 
+  /* Slightly larger opening paragraph on a richer detail page */
+  .research-lede {
+    font-size: 1.06rem;
+    line-height: 1.66;
+    color: var(--global-text-color);
+    margin: 0 0 1.8rem;
+  }
+
+  /* Named sub-strands within a section */
+  .thread {
+    border-left: 3px solid var(--global-theme-color);
+    padding: 0.1rem 0 0.1rem 1.1rem;
+    margin: 0 0 1.4rem;
+
+    .thread-title {
+      font-weight: 700;
+      color: var(--global-text-color);
+      margin-bottom: 0.3rem;
+    }
+    p {
+      margin: 0;
+      color: var(--global-text-color-light);
+      line-height: 1.55;
+    }
+  }
+
+  /* Sponsor / funding acknowledgment */
+  .research-sponsors {
+    margin-top: 2.4rem;
+    padding-top: 1rem;
+    border-top: 1px solid $research-rule;
+    font-size: 0.86rem;
+    line-height: 1.55;
+    color: var(--global-text-color-light);
+  }
+
   .research-back {
     display: inline-block;
     margin-top: 2.4rem;

--- a/_sass/_research.scss
+++ b/_sass/_research.scss
@@ -1,209 +1,177 @@
 /*******************************************************************************
- * Styles for the Research pages (landing + detail)
+ * Styles for the Research pages (landing + detail).
+ * Minimal, paper-like, matching the site's whitespace theme. Accents use the
+ * global theme color so light/dark modes are handled automatically.
  ******************************************************************************/
 
-$research-accent-a: #667eea;
-$research-accent-b: #764ba2;
+$research-rule: rgba(128, 128, 128, 0.18);
 
-.research-container {
-  max-width: 1000px;
-  margin: 0 auto;
-  padding: 20px;
-}
+.research {
+  max-width: 100%;
 
-/* Intro / vision banner (shared by landing and detail pages) */
-.research-hero {
-  background: linear-gradient(135deg, $research-accent-a 0%, $research-accent-b 100%);
-  color: #fff;
-  padding: 34px 36px;
-  border-radius: 12px;
-  margin-bottom: 40px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.12);
-
-  .research-eyebrow {
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.78em;
-    opacity: 0.85;
-    margin-bottom: 10px;
-  }
-
-  h1 {
-    margin: 0 0 14px 0;
-    font-size: 1.7em;
-    font-weight: 600;
-    color: #fff;
-  }
-
-  p {
-    margin: 0;
-    font-size: 1.08em;
-    line-height: 1.6;
-    opacity: 0.96;
-  }
-}
-
-/* Group heading, e.g. "Research Directions" / "Impact Areas" */
-.research-group-header {
-  border-left: 4px solid $research-accent-a;
-  padding-left: 18px;
-  margin: 44px 0 22px 0;
-
-  h2 {
-    margin: 0 0 4px 0;
-    font-size: 1.35em;
-    font-weight: 600;
-    color: var(--global-text-color);
-  }
-
-  .research-group-sub {
-    margin: 0;
+  /* Short lead paragraph under the page title, when present */
+  .research-lead {
     color: var(--global-text-color-light);
-    font-size: 0.95em;
+    line-height: 1.6;
+    margin-bottom: 2.4rem;
   }
-}
 
-/* Grid of topic cards on the landing page */
-.research-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 20px;
-}
+  /* Section label: "Research Directions", "Impact Areas" */
+  .research-group {
+    margin: 2.6rem 0 1.2rem;
+    padding-bottom: 0.45rem;
+    border-bottom: 1px solid $research-rule;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--global-theme-color);
+  }
+  .research-group:first-child { margin-top: 0.5rem; }
 
-.research-card {
-  display: block;
-  background: var(--global-bg-color);
-  border: 1px solid rgba(102, 126, 234, 0.22);
-  border-left: 4px solid $research-accent-a;
-  border-radius: 12px;
-  padding: 22px 24px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
-  color: var(--global-text-color);
+  /* Landing list of topics */
+  .topic-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
 
-  &:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 8px 22px rgba(102, 126, 234, 0.18);
-    text-decoration: none;
+  .topic {
+    padding: 1.05rem 0;
+    border-bottom: 1px solid $research-rule;
+
+    &:last-child { border-bottom: none; }
+
+    .topic-head {
+      position: relative;
+      padding-left: 1.1rem;
+    }
+    .topic-head::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 0.55em;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--global-theme-color);
+    }
+
+    .topic-title {
+      font-size: 1.06rem;
+      font-weight: 600;
+      color: var(--global-theme-color);
+    }
+    .topic-title:hover { text-decoration: underline; }
+
+    .topic-desc {
+      color: var(--global-text-color);
+      line-height: 1.55;
+    }
+
+    .topic-tags { margin: 0.55rem 0 0 1.1rem; }
+  }
+
+  /* Detail page: lead problem statement */
+  .research-problem {
+    border-left: 3px solid var(--global-theme-color);
+    padding: 0.2rem 0 0.2rem 1.1rem;
+    margin: 0 0 2rem;
     color: var(--global-text-color);
+    line-height: 1.6;
+    font-size: 1.02rem;
   }
 
-  h3 {
-    margin: 0 0 10px 0;
-    font-size: 1.12em;
+  /* Detail page sections */
+  .research-section { margin: 2.2rem 0; }
+
+  .research-section > h2 {
+    font-size: 1.16rem;
+    font-weight: 600;
+    color: var(--global-text-color);
+    margin: 0 0 1rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid $research-rule;
+  }
+
+  /* Clean bullet points */
+  .bullets {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+      position: relative;
+      padding: 0.4rem 0 0.4rem 1.3rem;
+      line-height: 1.55;
+      color: var(--global-text-color);
+    }
+    li::before {
+      content: "";
+      position: absolute;
+      left: 0.15rem;
+      top: 0.85em;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--global-theme-color);
+      opacity: 0.7;
+    }
+  }
+
+  /* Selected work */
+  .works {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+      padding: 0.65rem 0;
+      line-height: 1.5;
+      border-bottom: 1px solid $research-rule;
+    }
+    li:last-child { border-bottom: none; }
+
+    .work-title { font-weight: 600; }
+    .work-title a { color: var(--global-theme-color); }
+    .work-venue {
+      color: var(--global-text-color-light);
+      font-size: 0.86rem;
+    }
+  }
+
+  /* Subtle tag chips (application sectors / capability tags) */
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.5rem;
+    padding: 0;
+    margin: 0.6rem 0 0;
+  }
+  .tag {
+    display: inline-block;
+    padding: 0.15rem 0.7rem;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    color: var(--global-theme-color);
+    border: 1px solid $research-rule;
+    border-radius: 999px;
+  }
+
+  .research-note {
+    background: rgba(128, 128, 128, 0.07);
+    border-radius: 6px;
+    padding: 0.85rem 1.1rem;
+    margin: 1.2rem 0;
+    line-height: 1.55;
+    font-size: 0.94rem;
+    color: var(--global-text-color-light);
+  }
+
+  .research-back {
+    display: inline-block;
+    margin-top: 2.4rem;
     font-weight: 600;
     color: var(--global-theme-color);
   }
-
-  p {
-    margin: 0 0 14px 0;
-    color: var(--global-text-color);
-    line-height: 1.55;
-    font-size: 0.96em;
-  }
-
-  .research-more {
-    font-size: 0.9em;
-    font-weight: 600;
-    color: $research-accent-a;
-  }
-}
-
-/* Tag chips (capabilities / sectors) */
-.research-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-  margin: 0 0 14px 0;
-}
-
-.research-tag {
-  background: rgba(102, 126, 234, 0.10);
-  color: var(--global-theme-color);
-  border: 1px solid rgba(102, 126, 234, 0.22);
-  border-radius: 999px;
-  padding: 3px 12px;
-  font-size: 0.8em;
-  line-height: 1.5;
-}
-
-/* Detail-page content sections */
-.research-section {
-  margin: 36px 0;
-
-  h2 {
-    font-size: 1.25em;
-    font-weight: 600;
-    color: var(--global-text-color);
-    border-bottom: 2px solid rgba(102, 126, 234, 0.25);
-    padding-bottom: 8px;
-    margin-bottom: 18px;
-  }
-}
-
-.research-bullets {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-
-  li {
-    position: relative;
-    padding: 8px 0 8px 26px;
-    line-height: 1.55;
-    color: var(--global-text-color);
-    border-bottom: 1px solid rgba(128, 128, 128, 0.14);
-
-    &:last-child { border-bottom: none; }
-
-    &::before {
-      content: "▹";
-      position: absolute;
-      left: 4px;
-      color: $research-accent-a;
-      font-weight: 700;
-    }
-  }
-}
-
-/* Selected work list */
-.research-works {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-
-  li {
-    padding: 12px 0;
-    border-bottom: 1px solid rgba(128, 128, 128, 0.14);
-    line-height: 1.5;
-
-    &:last-child { border-bottom: none; }
-  }
-
-  .work-title { font-weight: 600; color: var(--global-text-color); }
-  .work-title a { color: var(--global-theme-color); }
-  .work-venue { color: var(--global-text-color-light); font-size: 0.9em; }
-}
-
-.research-note {
-  background: rgba(102, 126, 234, 0.08);
-  border-left: 3px solid $research-accent-a;
-  border-radius: 6px;
-  padding: 14px 18px;
-  margin: 20px 0;
-  color: var(--global-text-color);
-  line-height: 1.55;
-  font-size: 0.96em;
-}
-
-.research-back {
-  display: inline-block;
-  margin: 30px 0 10px 0;
-  font-weight: 600;
-  color: $research-accent-a;
-}
-
-@media (max-width: 768px) {
-  .research-container { padding: 15px; }
-  .research-hero { padding: 26px 22px; }
-  .research-grid { grid-template-columns: 1fr; }
 }

--- a/_sass/_research.scss
+++ b/_sass/_research.scss
@@ -168,42 +168,6 @@ $research-rule: rgba(128, 128, 128, 0.18);
     color: var(--global-text-color-light);
   }
 
-  /* Slightly larger opening paragraph on a richer detail page */
-  .research-lede {
-    font-size: 1.06rem;
-    line-height: 1.66;
-    color: var(--global-text-color);
-    margin: 0 0 1.8rem;
-  }
-
-  /* Named sub-strands within a section */
-  .thread {
-    border-left: 3px solid var(--global-theme-color);
-    padding: 0.1rem 0 0.1rem 1.1rem;
-    margin: 0 0 1.4rem;
-
-    .thread-title {
-      font-weight: 700;
-      color: var(--global-text-color);
-      margin-bottom: 0.3rem;
-    }
-    p {
-      margin: 0;
-      color: var(--global-text-color-light);
-      line-height: 1.55;
-    }
-  }
-
-  /* Sponsor / funding acknowledgment */
-  .research-sponsors {
-    margin-top: 2.4rem;
-    padding-top: 1rem;
-    border-top: 1px solid $research-rule;
-    font-size: 0.86rem;
-    line-height: 1.55;
-    color: var(--global-text-color-light);
-  }
-
   .research-back {
     display: inline-block;
     margin-top: 2.4rem;


### PR DESCRIPTION
Follow-up to the merged #11. These three commits did not make it into that PR before it was merged, so they are collected here as a new PR against `master`.

## What's in this PR

**1. Restyle to match the site's whitespace theme**
- Replace the heavy purple gradient banners/cards with a clean, paper-like layout.
- Landing page becomes a bulleted topic list grouped under `Research Directions` / `Impact Areas`; the verbose hero/vision block and group subtitles are removed in favor of the layout's native title.
- Detail pages lead with a problem statement, then bullet-point capabilities, a linked selected-work list, and subtle sector tags.
- Accents use the global theme color, so light and dark mode are handled automatically.

**2. Rename the tab**
- `Research` → **`Research & Impact`**, reflecting the two-section structure.

**3. Rework the person-centric video direction**
- Retitled to **"Understanding People in Long, Real-World Video"** (detail page and landing card).
- Reworked content: problem statement, "What we work on", an "Emerging directions" narrative (IDSelect linked inline), a nine-item selected-work list (including the previously-missing arXiv link for *From 3D Pose to Prose*), and application tags.

## Notes
- Verified with a full `jekyll build` (Ruby 3.2.6, matching the deploy workflow) in both light and dark mode.
- `_site/` is intentionally not committed — the deploy workflow rebuilds it and publishes to `gh-pages` on merge to `master`.

## Files
- `_pages/research.md` and `_pages/research-*.md`
- `_sass/_research.scss`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_