### PR TITLE
update

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -22,11 +22,12 @@ Feng Liu is an Assistant Professor in the <a href="https://drexel.edu/cci/academ
 <a href="https://vilab-group.com/">Visual Intelligence Lab</a>
 
 **Research interests**
+My group develops visual intelligence for humans and the physical world, organized into four research directions (see the <a href="{{ '/research/' | relative_url }}">Research</a> page for details):
 <ul>
-<li><b>3D Computer Vision</b>: 3D object/scene understanding; 3D generation; VR/AR; 3D vision+language understanding</li>
-<li><b>AI + X</b>: Education; Healthcare</li>
-<li><b>3D Human Digitization</b>: Modeling, reconstruction and rendering; Biomechanics</li>
-<li><b>Generative AI</b>: Explainability, generalization and controllability in generative models; DeepFake detection</li>
-<li><b>Biometric Recognition</b>: Face and gait recognition; Person re-identification</li>
+<li><b><a href="{{ '/research/physical-human-intelligence/' | relative_url }}">Physical Human Intelligence</a></b>: 3D humans, motion, biomechanics, and embodied AI</li>
+<li><b><a href="{{ '/research/person-centric-video/' | relative_url }}">Understanding People in Long, Real-World Video</a></b>: identity, activity, and evidence across long, multi-camera footage</li>
+<li><b><a href="{{ '/research/biometrics-digital-identity/' | relative_url }}">Trustworthy Biometrics and Digital Identity</a></b>: recognition, deepfake detection, and synthetic identity</li>
+<li><b><a href="{{ '/research/generative-multimodal-ai/' | relative_url }}">Generative and Multimodal AI for the Physical World</a></b>: 3D generation, vision-language models, simulation, and domain generalization</li>
 </ul>
+<b>Impact areas</b>: <a href="{{ '/research/ai-health-human-performance/' | relative_url }}">AI for Health and Human Performance</a> and <a href="{{ '/research/ai-education-scientific-learning/' | relative_url }}">AI for Education and Scientific Learning</a>.
 

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 permalink: /research/
-title: Research & Impact
+title: Research
 description:
 nav: true
 importance: 0


### PR DESCRIPTION
The merge of #12 captured the branch only up to the video-page retitle; these two follow-up commits did not make it into `master`:

1. **Rename the tab** `Research & Impact` → **`Research`**.
2. **Align the homepage** — replace the old five-topic "Research interests" list on the About page with the four research directions (each linking to its detail page) plus a trailing line linking the two impact areas, so the homepage and the Research page share one taxonomy.

Verified with a full `jekyll build` (Ruby 3.2.6). `_site/` is not committed; the deploy workflow rebuilds it and publishes to `gh-pages` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_