### PR TITLE
update

### DIFF
--- a/_pages/research-human.md
+++ b/_pages/research-human.md
@@ -62,6 +62,24 @@ importance: 90
   </div>
 
   <div class="research-section">
+    <h2>Community leadership</h2>
+    <div class="workshop">
+      <div class="workshop-title"><a href="https://physhuman.github.io/" target="_blank">1st PhysHuman Workshop @ CVPR 2026 &mdash; Physically Grounded Human Perception and Modeling</a></div>
+      <div class="workshop-meta">Denver, CO &middot; June 4, 2026 &middot; Co-organized and led by Feng Liu</div>
+      <p>Vision and generative models can reconstruct and synthesize humans with high visual fidelity,
+      but rarely model how bodies move under real-world physical constraints. This workshop brings
+      together computer vision, biomechanics, simulation, and XR researchers to make physical
+      quantities &mdash; ground reaction forces, center-of-mass dynamics, joint torques, and
+      contact/friction states &mdash; first-class targets for learning from video, IMU, and
+      multimodal data, and to benchmark the physical plausibility of human perception, modeling, and
+      generation.</p>
+      <p class="workshop-keynotes">Keynotes: Jiajun Wu (Stanford) &middot; Xin Li (Texas A&amp;M)
+      &middot; Christian Theobalt (MPI for Informatics) &middot; Ehsan Adeli (Stanford) &middot;
+      Dima Damen (Bristol &amp; Google DeepMind).</p>
+    </div>
+  </div>
+
+  <div class="research-section">
     <h2>Where it applies</h2>
     <div class="tags">
       <span class="tag">Digital health</span>

--- a/_sass/_research.scss
+++ b/_sass/_research.scss
@@ -168,6 +168,31 @@ $research-rule: rgba(128, 128, 128, 0.18);
     color: var(--global-text-color-light);
   }
 
+  /* Highlighted callout, e.g. a workshop we organize */
+  .workshop {
+    border: 1px solid $research-rule;
+    border-left: 3px solid var(--global-theme-color);
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+
+    .workshop-title {
+      font-weight: 700;
+      color: var(--global-theme-color);
+      line-height: 1.4;
+    }
+    .workshop-meta {
+      font-size: 0.85rem;
+      color: var(--global-text-color-light);
+      margin: 0.25rem 0 0.7rem;
+    }
+    p { margin: 0 0 0.6rem; line-height: 1.55; }
+    .workshop-keynotes {
+      font-size: 0.9rem;
+      color: var(--global-text-color-light);
+      margin: 0;
+    }
+  }
+
   .research-back {
     display: inline-block;
     margin-top: 2.4rem;


### PR DESCRIPTION
Adds a **Community leadership** section to `/research/physical-human-intelligence/` highlighting the **1st PhysHuman Workshop — Physically Grounded Human Perception and Modeling** at CVPR 2026 (Denver, June 4, 2026), co-organized and led by Feng Liu.

The callout keeps it concise — scope description, keynote roster (Jiajun Wu, Xin Li, Christian Theobalt, Ehsan Adeli, Dima Damen), and a link to the full workshop site (schedule, accepted papers, CFP) at [physhuman.github.io](https://physhuman.github.io/) — rather than duplicating the workshop page.

Adds a `.workshop` callout style to `_research.scss` (theme-variable driven, so light/dark both work). Verified with a full `jekyll build` (Ruby 3.2.6) and a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_