### PR TITLE
update

### DIFF
--- a/_pages/research-human.md
+++ b/_pages/research-human.md
@@ -65,14 +65,16 @@ importance: 90
     <h2>Community leadership</h2>
     <div class="workshop">
       <div class="workshop-title"><a href="https://physhuman.github.io/" target="_blank">1st PhysHuman Workshop @ CVPR 2026 &mdash; Physically Grounded Human Perception and Modeling</a></div>
-      <div class="workshop-meta">Denver, CO &middot; June 4, 2026 &middot; Co-organized and led by Feng Liu</div>
+      <div class="workshop-meta">Denver, CO &middot; June 4, 2026 &middot; Co-organized by Feng Liu</div>
       <p>Vision and generative models can reconstruct and synthesize humans with high visual fidelity,
       but rarely model how bodies move under real-world physical constraints. This workshop brings
       together computer vision, biomechanics, simulation, and XR researchers to make physical
       quantities &mdash; ground reaction forces, center-of-mass dynamics, joint torques, and
       contact/friction states &mdash; first-class targets for learning from video, IMU, and
       multimodal data, and to benchmark the physical plausibility of human perception, modeling, and
-      generation.</p>
+      generation. These physically grounded representations are increasingly central to
+      <b>embodied AI</b> and <b>humanoid robotics</b>, where agents must perceive, imitate, and act
+      with human-like contact and force.</p>
       <p class="workshop-keynotes">Keynotes: Jiajun Wu (Stanford) &middot; Xin Li (Texas A&amp;M)
       &middot; Christian Theobalt (MPI for Informatics) &middot; Ehsan Adeli (Stanford) &middot;
       Dima Damen (Bristol &amp; Google DeepMind).</p>


### PR DESCRIPTION
Follow-up to the merged #14, which landed before this refinement was pushed. Two small wording changes to the PhysHuman callout on `/research/physical-human-intelligence/`:

1. **"Co-organized and led by Feng Liu"** → **"Co-organized by Feng Liu"** (drop "and led").
2. Add a closing line connecting the work to **embodied AI** and **humanoid robotics**: *"These physically grounded representations are increasingly central to embodied AI and humanoid robotics, where agents must perceive, imitate, and act with human-like contact and force."*

Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_