### PR TITLE
update

### DIFF
--- a/_news/news_ae_tifs.md
+++ b/_news/news_ae_tifs.md
@@ -3,6 +3,4 @@ layout: post
 date: 2026-02-06
 inline: true
 ---
-<span style="color: blue;"> 
 I am serving as an Associate Editor for <a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=10206">IEEE Transactions on Information Forensics and Security (T-IFS)</a>.
-</span>

--- a/_news/news_grant_longsview.md
+++ b/_news/news_grant_longsview.md
@@ -3,6 +3,4 @@ layout: post
 date: 2026-03-10
 inline: true
 ---
-<span style="color: blue;"> 
 Received two Drexel internal grants (2x <a href="https://drexel.edu/engineering/news-events/news/archive/2026/March/faculty-awards-carleone-longsview-grimes-2026/">Longsview Fellowship</a>)!
-</span>

--- a/_news/news_paper_aied2026.md
+++ b/_news/news_paper_aied2026.md
@@ -3,9 +3,7 @@ layout: post
 date: 2026-03-23
 inline: true
 ---
-<span style="color: blue;"> 
 Two papers, <a href="https://vilab-group.com/project/drawsim-pd/">DrawSim-PD</a> and <a href="https://vilab-group.com/project/sciibi/">SciIBI</a>, have been accepted by <a href="https://www.aied-conference.org/2026">AIED 2026</a>! Congratulations to Ariji, Yixuan and all co-authors.
-</span>
 
 
 

--- a/_news/news_paper_cvpr26.md
+++ b/_news/news_paper_cvpr26.md
@@ -3,6 +3,4 @@ layout: post
 date: 2026-02-21
 inline: true
 ---
-<span style="color: blue;"> 
 Two papers, “BioCoach” and “Bridge,” have been accepted by CVPR 2026! Congratulations to Yuyang and all co-authors!
-</span>

--- a/_news/news_paper_miccai26.md
+++ b/_news/news_paper_miccai26.md
@@ -3,9 +3,7 @@ layout: post
 date: 2026-05-07
 inline: true
 ---
-<span style="color: blue;"> 
 Our paper "BioGait-VLM" has been provisionally accepted at <a href="https://conferences.miccai.org/2026/">MICCAI 2026</a> (Acceptance rate: 9%). Congratulations to Anthony, Yuyang, and all co-authors!
-</span>
 
 
 

--- a/_news/news_workshop_PhysHuman.md
+++ b/_news/news_workshop_PhysHuman.md
@@ -3,6 +3,4 @@ layout: post
 date: 2026-01-10
 inline: true
 ---
-<span style="color: blue;"> 
-We are organizing the First <a href="https://physhuman.github.io/" style="color: blue; text-decoration: underline;">PhysHuman</a> Workshop @ CVPR 2026 (Denver), focusing on physically grounded human perception, modeling, and generation.
-</span>
+We are organizing the First <a href="https://physhuman.github.io/">PhysHuman</a> Workshop @ CVPR 2026 (Denver), focusing on physically grounded human perception, modeling, and generation.


### PR DESCRIPTION
Removes the blue text styling from the six recent news entries so all news uses the default text color.

Strips the `<span style="color: blue;">…</span>` wrapper from:
- `news_workshop_PhysHuman.md` (also removes the PhysHuman link's inline blue style)
- `news_ae_tifs.md`
- `news_grant_longsview.md`
- `news_paper_aied2026.md`
- `news_paper_cvpr26.md`
- `news_paper_miccai26.md`

Verified with a full `jekyll build` (Ruby 3.2.6): the rendered homepage news feed has no remaining inline blue styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_