### PR TITLE
update

### DIFF
--- a/_news/news_award_fair.md
+++ b/_news/news_award_fair.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-06-29
+inline: true
+---
+<span style="color: blue;">
+Received an Outstanding Researcher Award from the <a href="https://faircenter.stanford.edu" style="color: blue; text-decoration: underline;">FAIR Center</a> at Stanford University for our work on physics-grounded video analysis for interpretable gait assessment in DCM.
+</span>


### PR DESCRIPTION
Adds a new news entry (`_news/news_award_fair.md`, dated June 29, 2026) highlighting the **Outstanding Researcher Award from the FAIR Center at Stanford University**, which supports attending the OpenSim+ Advanced User Workshop (Stanford, March 9–11, 2027).

Styled in blue as a recent-news highlight, with a link to [faircenter.stanford.edu](https://faircenter.stanford.edu). It sorts to the top of the news feed (newest date).

Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_