### PR TITLE
update

### DIFF
--- a/_news/news_award_anthropic.md
+++ b/_news/news_award_anthropic.md
@@ -4,5 +4,5 @@ date: 2026-07-17
 inline: true
 ---
 <span style="color: blue;">
-Received a $25,000 Anthropic AI for Science Award &mdash; one of a cohort of up to 50 supported projects &mdash; with <a href="https://drexel.edu/engineering/about/faculty-staff/M/mcdonald-matthew/" style="color: blue; text-decoration: underline;">Dr. Matthew McDonald</a>, to advance physics-grounded generative AI for organic crystal discovery.
+Received a $25,000 Anthropic AI for Science Award with <a href="https://drexel.edu/engineering/about/faculty-staff/M/mcdonald-matthew/" style="color: blue; text-decoration: underline;">Dr. Matthew McDonald</a>, to advance physics-grounded generative AI for organic crystal discovery.
 </span>


### PR DESCRIPTION
Follow-up to the merged #18 (which landed before this edit). Removes the "— one of a cohort of up to 50 supported projects —" clause from the Anthropic AI for Science Award news entry.

The entry now reads:

> Received a $25,000 Anthropic AI for Science Award with [Dr. Matthew McDonald](https://drexel.edu/engineering/about/faculty-staff/M/mcdonald-matthew/), to advance physics-grounded generative AI for organic crystal discovery.

Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_