### PR TITLE
update

### DIFF
--- a/_news/news_paper_siggraphasia26.md
+++ b/_news/news_paper_siggraphasia26.md
@@ -1,0 +1,6 @@
+---
+layout: post
+date: 2026-07-18
+inline: true
+---
+One paper has been accepted at <a href="https://asia.siggraph.org/2026/">SIGGRAPH Asia 2026</a>! Congratulations to Yixuan and all co-authors!


### PR DESCRIPTION
Adds a news entry (`_news/news_paper_siggraphasia26.md`, dated July 18, 2026):

> One paper has been accepted at [SIGGRAPH Asia 2026](https://asia.siggraph.org/2026/)! Congratulations to Yixuan and all co-authors!

Non-blue, to match the other paper-acceptance entries (CVPR'26, MICCAI'26, AIED'26). Sorts to the top of the feed (newest date). Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_