### PR TITLE
update

### DIFF
--- a/_news/news_paper_siggraphasia26.md
+++ b/_news/news_paper_siggraphasia26.md
@@ -3,4 +3,6 @@ layout: post
 date: 2026-07-18
 inline: true
 ---
-One paper has been accepted at <a href="https://asia.siggraph.org/2026/">SIGGRAPH Asia 2026</a>! Congratulations to Yixuan and all co-authors!
+<span style="color: blue;">
+One paper has been accepted at <a href="https://asia.siggraph.org/2026/" style="color: blue; text-decoration: underline;">SIGGRAPH Asia 2026</a>! Congratulations to Yixuan and all co-authors!
+</span>


### PR DESCRIPTION
Follow-up to the merged #20 (which landed the non-blue version). Wraps the SIGGRAPH Asia 2026 news entry in the blue highlight style (matching the other highlighted news), including the blue underlined SIGGRAPH link.

> One paper has been accepted at [SIGGRAPH Asia 2026](https://asia.siggraph.org/2026/)! Congratulations to Yixuan and all co-authors!

Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_