### PR TITLE
update

### DIFF
--- a/_pages/others.md
+++ b/_pages/others.md
@@ -1,0 +1,18 @@
+---
+layout: none
+permalink: /others/
+sitemap: false
+---
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url={{ '/awards-services/' | relative_url }}">
+  <link rel="canonical" href="{{ '/awards-services/' | relative_url }}">
+  <title>Redirecting&hellip;</title>
+</head>
+<body>
+  <p>This page has moved to <a href="{{ '/awards-services/' | relative_url }}">Awards &amp; Services</a>. Redirecting&hellip;</p>
+  <script>location.replace("{{ '/awards-services/' | relative_url }}");</script>
+</body>
+</html>


### PR DESCRIPTION
After renaming the Awards & Services permalink to `/awards-services/` (in #22), the old `/others/` URL 404s for existing bookmarks and inbound links.

This adds a lightweight meta-refresh + `location.replace` redirect page at `/others/` that forwards to `/awards-services/`, with a `canonical` link. It's kept out of the navbar (no `nav:` flag) and out of the sitemap (`sitemap: false`), using the existing `none` layout so it emits a minimal standalone HTML document.

Verified with a full `jekyll build` (Ruby 3.2.6): `/others/index.html` redirects to `/awards-services/`, the nav no longer lists `/others/`, and `/awards-services/` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_