### PR TITLE
update

### DIFF
--- a/_pages/awards.md
+++ b/_pages/awards.md
@@ -14,15 +14,15 @@ importance: 4
     <ul class="works">
       <li>
         <span class="work-title">Anthropic AI for Science Award</span><br>
-        <span class="work-venue">2026 &middot; $25,000 &middot; with <a href="https://drexel.edu/engineering/about/faculty-staff/M/mcdonald-matthew/" target="_blank">Dr. Matthew McDonald</a></span>
+        <span class="work-venue">2026 &middot; $25,000</span>
       </li>
       <li>
         <span class="work-title">Outstanding Researcher Award, <a href="https://faircenter.stanford.edu" target="_blank">FAIR Center</a>, Stanford University</span><br>
         <span class="work-venue">2026</span>
       </li>
       <li>
-        <span class="work-title"><a href="https://drexel.edu/engineering/news-events/news/archive/2026/March/faculty-awards-carleone-longsview-grimes-2026/" target="_blank">Longsview Fellowship</a>, Drexel University (&times;2)</span><br>
-        <span class="work-venue">2026</span>
+        <span class="work-title"><a href="https://drexel.edu/engineering/news-events/news/archive/2026/March/faculty-awards-carleone-longsview-grimes-2026/" target="_blank">Longsview Fellowship</a> (&times;2)</span><br>
+        <span class="work-venue">2026 &middot; Drexel University</span>
       </li>
       <li>
         <span class="work-title">NVIDIA Academic Grant Program Award</span><br>


### PR DESCRIPTION
Two small edits to the Grants & Awards list on the Awards & Services page:

1. **Anthropic AI for Science Award** — removed "with Dr. Matthew McDonald"; the line now reads `2026 · $25,000`.
2. **Longsview Fellowship** — moved `(×2)` to right after the name (`Longsview Fellowship (×2)`) and moved "Drexel University" to the subtitle (`2026 · Drexel University`).

Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_