### PR TITLE
update

### DIFF
--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -30,6 +30,14 @@ importance: 2
         <span class="work-venue">Winter 2025&ndash;2026 &middot; Drexel University</span>
       </li>
       <li>
+        <span class="work-title">CS 583 &middot; Introduction to Computer Vision</span><br>
+        <span class="work-venue">Fall 2024&ndash;2025 &middot; Drexel University</span>
+      </li>
+      <li>
+        <span class="work-title">CS 435 &middot; Computational Photography</span><br>
+        <span class="work-venue">Winter 2024&ndash;2025 &middot; Drexel University</span>
+      </li>
+      <li>
         <span class="work-title">CSE 803 &middot; Computer Vision</span><br>
         <span class="work-venue">Fall 2023&ndash;2024 &middot; Michigan State University</span>
       </li>


### PR DESCRIPTION
Adds the 2024–2025 offerings to the Teaching page's Previous Courses list:

- CS 583 · Introduction to Computer Vision — Fall 2024–2025 (Drexel)
- CS 435 · Computational Photography — Winter 2024–2025 (Drexel)

Previous Courses now runs newest-first: 2025–2026 (CS 583, CS 435), 2024–2025 (CS 583, CS 435), then CSE 803 (Fall 2023–2024, Michigan State). Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_