### PR TITLE
update

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -18,8 +18,9 @@ importance: 1
 
 Feng Liu is an Assistant Professor in the <a href="https://drexel.edu/cci/academics/computer-science-department/">Department of Computer Science</a> at <a href="https://drexel.edu/">Drexel University</a>.
 
-**Research Group**
-<a href="https://vilab-group.com/">Visual Intelligence Lab</a>
+**Research Group:** <a href="https://vilab-group.com/">Visual Intelligence Lab</a>
+
+We always look for passionate students to join the team in terms of RA/externship/internship/visiting students (more info <a href="https://vilab-group.com/#vacancies">here</a>)!
 
 **Research interests**
 My group develops visual intelligence for humans and the physical world, organized into four research directions (see the <a href="{{ '/research/' | relative_url }}">Research</a> page for details):


### PR DESCRIPTION
Updates the About page:

- `**Research Group**` / Visual Intelligence Lab → **`Research Group:` Visual Intelligence Lab** (single line with a colon).
- Adds a recruitment note: *"We always look for passionate students to join the team in terms of RA/externship/internship/visiting students ([more info](https://vilab-group.com/#vacancies))!"*

Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_