### PR TITLE
update

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 {% if site.footer_fixed %}
 <footer class="fixed-bottom">
   <div class="container mt-0">
-    <div style="text-align: center; margin-top: 0px; margin-bottom: 0px; transform: scale(0.375); transform-origin: center;">
+    <div style="text-align: center; margin-top: 0px; margin-bottom: 0px; zoom: 0.375;">
       <script type='text/javascript' id='clustrmaps' src='//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI'></script>
     </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
@@ -17,7 +17,7 @@
 {% else %}
 <footer class="sticky-bottom mt-5">
   <div class="container">
-    <div style="text-align: center; margin-top: 0px; margin-bottom: 0px; transform: scale(0.375); transform-origin: center;">
+    <div style="text-align: center; margin-top: 0px; margin-bottom: 0px; zoom: 0.375;">
       <script type='text/javascript' id='clustrmaps' src='//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI'></script>
     </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.


### PR DESCRIPTION
Fixes the footer ClustrMaps visitor map, a known al-folio issue where the map leaves a large blank area / pushes the footer over page content.

**Cause:** the wrapper used `transform: scale(0.375)`, which shrinks the map visually but not its layout box, so the footer still reserved the map's full original height.

**Fix:** replaced `transform: scale(0.375); transform-origin: center;` with `zoom: 0.375;` in both footer variants (`footer_fixed` true/false). `zoom` shrinks the actual layout box, so the reserved space matches the visible map — no blank gap, no overlap. Universally supported in current browsers.

Built and confirmed the change is in the output (`zoom: 0.375` present, `transform: scale` gone).

Note: I can't render the live ClustrMaps widget from the build environment (its CDN is blocked here), so please verify visually after deploy (hard refresh). If the map still doesn't appear at all, that's a separate issue (the ClustrMaps `d=` token may need regenerating from your account), and its white background (`cl=ffffff`) can look bright in dark mode — happy to address either if you see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_