### PR TITLE
update

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,6 @@
 {% if site.footer_fixed %}
 <footer class="fixed-bottom">
   <div class="container mt-0">
-    <div style="text-align: center; margin-top: 0px; margin-bottom: 0px; zoom: 0.375;">
-      <script type='text/javascript' id='clustrmaps' src='//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI'></script>
-    </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
     {{ site.footer_text }}
     {% if site.impressum_path %}
@@ -17,9 +14,6 @@
 {% else %}
 <footer class="sticky-bottom mt-5">
   <div class="container">
-    <div style="text-align: center; margin-top: 0px; margin-bottom: 0px; zoom: 0.375;">
-      <script type='text/javascript' id='clustrmaps' src='//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=sqFWS0AtkBNtwJ3zB6bx8Lw3IX7gRxeXIDo70dh7-NI'></script>
-    </div>
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
     {{ site.footer_text }}
     {% if site.impressum_path %}


### PR DESCRIPTION
ClustrMaps has been unreachable since 2026, so the footer widget only rendered a dead/blank element. This removes the ClustrMaps `<div>` and `<script>` from both footer variants (`footer_fixed` true/false).

The rest of the footer (copyright, Impressum, last-updated) is unchanged. Verified with a full `jekyll build` (Ruby 3.2.6): no `clustrmaps` references remain in the output and the footer still renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_