### PR TITLE
update

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,7 +3,7 @@ layout: aboutnew
 title: About
 permalink: /
 description: >
-    <p><b>Assistant Professor</b><br>Department of Computer Science<br>Drexel University<br>liufeng2915@gmail.com; fl397@drexel.edu</p>
+    <p><b>Assistant Professor</b><br>Department of Computer Science<br>Drexel University</p>
 
 profile:
   align: right


### PR DESCRIPTION
Removes `liufeng2915@gmail.com; fl397@drexel.edu` (and the trailing `<br>`) from the About page header description. The Assistant Professor / Department / University lines are unchanged.

Verified with a full `jekyll build` (Ruby 3.2.6): no email addresses remain on the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_