### PR TITLE
update

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,7 +3,7 @@ layout: aboutnew
 title: About
 permalink: /
 description: >
-    <p><b>Assistant Professor</b><br>Department of Computer Science<br>Drexel University</p>
+    <p><b>Assistant Professor</b><br><a href="https://drexel.edu/cci/academics/computer-science-department/">Department of Computer Science</a><br><a href="https://drexel.edu/">Drexel University</a></p>
 
 profile:
   align: right
@@ -15,8 +15,6 @@ selected_papers: true # includes a list of papers marked as "selected={true}"
 social: false  # includes social icons at the bottom of the page
 importance: 1
 ---
-
-Feng Liu is an Assistant Professor in the <a href="https://drexel.edu/cci/academics/computer-science-department/">Department of Computer Science</a> at <a href="https://drexel.edu/">Drexel University</a>.
 
 **Research Group:** <a href="https://vilab-group.com/">Visual Intelligence Lab</a>
 


### PR DESCRIPTION
Two About-page edits:

1. **Add links** in the header — "Department of Computer Science" → the Drexel CS department page, and "Drexel University" → drexel.edu.
2. **Remove the duplicate sentence** "Feng Liu is an Assistant Professor in the Department of Computer Science at Drexel University." from the body, since the header already conveys the same info (now with the links).

The body now opens directly with the **Research Group:** line. Verified with a full `jekyll build` (Ruby 3.2.6): the duplicate sentence is gone and both header links render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_