### PR TITLE
update

### DIFF
--- a/_news/news_award_anthropic.md
+++ b/_news/news_award_anthropic.md
@@ -4,5 +4,5 @@ date: 2026-07-17
 inline: true
 ---
 <span style="color: blue;">
-Received a $25,000 Anthropic AI for Science Award with <a href="https://drexel.edu/engineering/about/faculty-staff/M/mcdonald-matthew/" style="color: blue; text-decoration: underline;">Dr. Matthew McDonald</a>, to advance physics-grounded generative AI for organic crystal discovery.
+Received a $25,000 Anthropic AI for Science Award to advance physics-grounded generative AI for organic crystal discovery, in collaboration with <a href="https://drexel.edu/engineering/about/faculty-staff/M/mcdonald-matthew/" style="color: blue; text-decoration: underline;">Dr. Matthew McDonald</a>.
 </span>


### PR DESCRIPTION
Rewords the Anthropic AI for Science Award news entry so Dr. Matthew McDonald is clearly a **collaborator**, not a co-PI:

> Received a $25,000 Anthropic AI for Science Award to advance physics-grounded generative AI for organic crystal discovery, **in collaboration with** Dr. Matthew McDonald.

("with X" could read as a joint/co-PI award; "in collaboration with" is the standard way to denote a collaborator.) Verified with a full `jekyll build` (Ruby 3.2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_