### PR TITLE
update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,6 +100,7 @@ collections:
 
 news_scrollable: true
 news_limit: # leave blank to include all the news in the `_news` folder 10
+news_start_year: 2025 # only show news items dated in this year or later (leave blank to show all)
 
 # -----------------------------------------------------------------------------
 # Jekyll settings

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -6,6 +6,8 @@
       <table class="table table-sm table-borderless">
       {% assign news = site.news | reverse %}
       {% for item in news limit: site.news_limit %}
+        {% assign item_year = item.date | date: "%Y" | times: 1 %}
+        {% if site.news_start_year == blank or item_year >= site.news_start_year %}
         <tr>
           <th scope="row">{{ item.date | date: "%b %-d, %Y" }}</th>
           <td>
@@ -16,6 +18,7 @@
             {% endif %}
           </td>
         </tr>
+        {% endif %}
       {% endfor %}
       </table>
     </div>


### PR DESCRIPTION
Show only news items dated 2025 or later.

- Add `news_start_year: 2025` to `_config.yml` (leave blank to show all).
- Filter the news loop in `_includes/news.html` by that year.

Verified with a build: the feed now shows only 2025–2026 items (18 rows); 2020–2024 items are hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_