### PR TITLE
update

### DIFF
--- a/_pages/awards.md
+++ b/_pages/awards.md
@@ -47,8 +47,9 @@ importance: 4
   </div>
 
   <div class="research-section">
-    <h2>Area Chair</h2>
+    <h2>Area Chair / Senior Program Committee</h2>
     <ul class="bullets">
+      <li>AAAI 2027</li>
       <li>NeurIPS 2026</li>
       <li>ICLR 2026</li>
       <li>CVPR 2026</li>


### PR DESCRIPTION
Add **AAAI 2027** (Senior Program Committee) to the Awards & Services page. Since AAAI's Senior Program Committee is the area-chair-level role, the section header is broadened from "Area Chair" to **"Area Chair / Senior Program Committee"**, with AAAI 2027 listed at the top. Verified with a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_