### PR TITLE
update

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -38,14 +38,22 @@ let transTheme = () => {
 
 
 let initTheme = (theme) => {
-  if (theme == null) {
-    const userPref = window.matchMedia;
-    if (userPref && userPref('(prefers-color-scheme: dark)').matches) {
-        theme = 'dark';
-    }
+  // Default to light on all devices (ignore the OS prefers-color-scheme) so
+  // the site looks consistent everywhere. Visitors can still switch to dark
+  // with the toggle, and that explicit choice is remembered in localStorage.
+  if (theme == null || (theme !== "dark" && theme !== "light")) {
+    theme = "light";
   }
   setTheme(theme);
 }
 
+
+// One-time reset: the previous logic auto-saved a theme based on each device's
+// OS setting (so phones in dark mode persisted "dark"). Clear that once so every
+// device starts from the new light default; explicit toggles afterward stick.
+if (localStorage.getItem("theme_reset_v2") == null) {
+  localStorage.removeItem("theme");
+  localStorage.setItem("theme_reset_v2", "1");
+}
 
 initTheme(localStorage.getItem("theme"));


### PR DESCRIPTION
Fix the inconsistent light/dark appearance across devices.

**Cause:** `assets/js/theme.js` had no saved-preference default, so it followed each device's OS `prefers-color-scheme` — dark on a phone in dark mode, light on a laptop in light mode — and it auto-saved that choice to `localStorage`.

**Fix:**
- Default the theme to **light** on all devices when there's no explicit choice (stop following the OS setting).
- Add a **one-time `localStorage` reset** so devices that previously auto-saved `dark` also start fresh on the light default.
- The dark-mode toggle still works, and a manual choice is remembered.

Verified with a build. Note: this only changes the default/persistence logic — the dark theme itself is unchanged and still available via the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_