### PR TITLE
update

### DIFF
--- a/_data/coauthors.yml
+++ b/_data/coauthors.yml
@@ -191,3 +191,11 @@
 "Satyakam":
   - firstname: ["Siddharth"]
     url: https://engineering.msu.edu/faculty/siddharth-satyakam
+
+"Shen":
+  - firstname: ["Yixuan"]
+    url: https://www.yixuanshen.com/
+
+"Shen*":
+  - firstname: ["Yixuan"]
+    url: https://www.yixuanshen.com/


### PR DESCRIPTION
Add Yixuan Shen's homepage (https://www.yixuanshen.com/) to `_data/coauthors.yml` — he was previously in the "not found" set. Added under both `Shen` and `Shen*` keys (equal-contribution), so his name links across all 5 of his 2026 papers.

Verified with a build: his name links on MyoFLAME, the deepfake audit, Non-Colliding IDs, From 3D Pose to Prose, and Can MLLMs See Science (the last via the `Shen*` key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_