### PR TITLE
update

### DIFF
--- a/_news/news_ac_neurips_aaai_iclr27.md
+++ b/_news/news_ac_neurips_aaai_iclr27.md
@@ -1,0 +1,6 @@
+---
+layout: post
+date: 2026-08-13
+inline: true
+---
+Serving as Area Chair for NeurIPS 2026, AAAI 2027, and ICLR 2027!


### PR DESCRIPTION
Add a news item dated Aug 13, 2026: "Serving as Area Chair for NeurIPS 2026, AAAI 2027, and ICLR 2027!". Non-blue, matching the other service/area-chair news; sorts to the top of the feed. Verified with a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDA4JXWq2tFZQrVTmJ9ND1)_